### PR TITLE
make Opus SDP always return 48khz and 2 channels

### DIFF
--- a/examples/client-publish-format-opus/main.go
+++ b/examples/client-publish-format-opus/main.go
@@ -39,9 +39,8 @@ func main() {
 	medi := &media.Media{
 		Type: media.TypeAudio,
 		Formats: []format.Format{&format.Opus{
-			PayloadTyp:   96,
-			SampleRate:   48000,
-			ChannelCount: 2,
+			PayloadTyp: 96,
+			IsStereo:   false,
 		}},
 	}
 

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -296,9 +296,8 @@ func TestNewFromMediaDescription(t *testing.T) {
 				},
 			},
 			&Opus{
-				PayloadTyp:   96,
-				SampleRate:   48000,
-				ChannelCount: 2,
+				PayloadTyp: 96,
+				IsStereo:   true,
 			},
 		},
 		{

--- a/pkg/format/opus_test.go
+++ b/pkg/format/opus_test.go
@@ -9,9 +9,8 @@ import (
 
 func TestOpusAttributes(t *testing.T) {
 	format := &Opus{
-		PayloadTyp:   96,
-		SampleRate:   48000,
-		ChannelCount: 2,
+		PayloadTyp: 96,
+		IsStereo:   true,
 	}
 	require.Equal(t, "Opus", format.String())
 	require.Equal(t, 48000, format.ClockRate())
@@ -21,9 +20,8 @@ func TestOpusAttributes(t *testing.T) {
 
 func TestOpusMediaDescription(t *testing.T) {
 	format := &Opus{
-		PayloadTyp:   96,
-		SampleRate:   48000,
-		ChannelCount: 2,
+		PayloadTyp: 96,
+		IsStereo:   true,
 	}
 
 	rtpmap, fmtp := format.Marshal()

--- a/pkg/media/medias_test.go
+++ b/pkg/media/medias_test.go
@@ -194,7 +194,7 @@ var casesMedias = []struct {
 			"a=control\r\n" +
 			"a=sendonly\r\n" +
 			"a=rtpmap:111 opus/48000/2\r\n" +
-			"a=fmtp:111 sprop-stereo=1\r\n" +
+			"a=fmtp:111 sprop-stereo=0\r\n" +
 			"a=rtpmap:103 ISAC/16000\r\n" +
 			"a=rtpmap:104 ISAC/32000\r\n" +
 			"a=rtpmap:9 G722/8000\r\n" +
@@ -230,9 +230,8 @@ var casesMedias = []struct {
 				Direction: DirectionSendonly,
 				Formats: []format.Format{
 					&format.Opus{
-						PayloadTyp:   111,
-						SampleRate:   48000,
-						ChannelCount: 2,
+						PayloadTyp: 111,
+						IsStereo:   false,
 					},
 					&format.Generic{
 						PayloadTyp: 103,
@@ -534,9 +533,8 @@ func TestMediasFindFormat(t *testing.T) {
 			Type: TypeAudio,
 			Formats: []format.Format{
 				&format.Opus{
-					PayloadTyp:   111,
-					SampleRate:   48000,
-					ChannelCount: 2,
+					PayloadTyp: 111,
+					IsStereo:   true,
 				},
 			},
 		},


### PR DESCRIPTION
RFC7587 mandates 48khz as sample rate and 2 channels inside the SDP. These values can be dynamically adjusted by the stream, but they must not be touched inside the SDP.