### PR TITLE
fix timestamp encode error after some hours

### DIFF
--- a/pkg/formatdecenc/rtph264/decoder.go
+++ b/pkg/formatdecenc/rtph264/decoder.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pion/rtp"
 
 	"github.com/aler9/gortsplib/v2/pkg/codecs/h264"
-	"github.com/aler9/gortsplib/v2/pkg/rtptimedec"
+	"github.com/aler9/gortsplib/v2/pkg/rtptime"
 )
 
 // ErrMorePacketsNeeded is returned when more packets are needed.
@@ -27,7 +27,7 @@ type Decoder struct {
 	// indicates the packetization mode.
 	PacketizationMode int
 
-	timeDecoder         *rtptimedec.Decoder
+	timeDecoder         *rtptime.Decoder
 	firstPacketReceived bool
 	fragmentedSize      int
 	fragments           [][]byte
@@ -39,7 +39,7 @@ type Decoder struct {
 
 // Init initializes the decoder.
 func (d *Decoder) Init() {
-	d.timeDecoder = rtptimedec.New(rtpClockRate)
+	d.timeDecoder = rtptime.NewDecoder(rtpClockRate)
 }
 
 // Decode decodes NALUs from a RTP/H264 packet.

--- a/pkg/formatdecenc/rtph265/decoder.go
+++ b/pkg/formatdecenc/rtph265/decoder.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pion/rtp"
 
 	"github.com/aler9/gortsplib/v2/pkg/codecs/h265"
-	"github.com/aler9/gortsplib/v2/pkg/rtptimedec"
+	"github.com/aler9/gortsplib/v2/pkg/rtptime"
 )
 
 // ErrMorePacketsNeeded is returned when more packets are needed.
@@ -26,7 +26,7 @@ type Decoder struct {
 	// indicates that NALUs have an additional field that specifies the decoding order.
 	MaxDONDiff int
 
-	timeDecoder         *rtptimedec.Decoder
+	timeDecoder         *rtptime.Decoder
 	firstPacketReceived bool
 	fragmentedSize      int
 	fragments           [][]byte
@@ -37,7 +37,7 @@ type Decoder struct {
 
 // Init initializes the decoder.
 func (d *Decoder) Init() {
-	d.timeDecoder = rtptimedec.New(rtpClockRate)
+	d.timeDecoder = rtptime.NewDecoder(rtpClockRate)
 }
 
 // Decode decodes NALUs from a RTP/H265 packet.

--- a/pkg/formatdecenc/rtplpcm/decoder.go
+++ b/pkg/formatdecenc/rtplpcm/decoder.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pion/rtp"
 
-	"github.com/aler9/gortsplib/v2/pkg/rtptimedec"
+	"github.com/aler9/gortsplib/v2/pkg/rtptime"
 )
 
 // Decoder is a RTP/LPCM decoder.
@@ -15,13 +15,13 @@ type Decoder struct {
 	SampleRate   int
 	ChannelCount int
 
-	timeDecoder *rtptimedec.Decoder
+	timeDecoder *rtptime.Decoder
 	sampleSize  int
 }
 
 // Init initializes the decoder.
 func (d *Decoder) Init() {
-	d.timeDecoder = rtptimedec.New(d.SampleRate)
+	d.timeDecoder = rtptime.NewDecoder(d.SampleRate)
 	d.sampleSize = d.BitDepth * d.ChannelCount / 8
 }
 

--- a/pkg/formatdecenc/rtpmjpeg/decoder.go
+++ b/pkg/formatdecenc/rtpmjpeg/decoder.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aler9/gortsplib/v2/pkg/codecs/jpeg"
 	"github.com/aler9/gortsplib/v2/pkg/formatdecenc/rtpmjpeg/headers"
-	"github.com/aler9/gortsplib/v2/pkg/rtptimedec"
+	"github.com/aler9/gortsplib/v2/pkg/rtptime"
 )
 
 // ErrMorePacketsNeeded is returned when more packets are needed.
@@ -96,7 +96,7 @@ var chmAcSymbols = []byte{ //nolint:dupl
 
 // Decoder is a RTP/M-JPEG decoder.
 type Decoder struct {
-	timeDecoder         *rtptimedec.Decoder
+	timeDecoder         *rtptime.Decoder
 	firstPacketReceived bool
 	fragmentedSize      int
 	fragments           [][]byte
@@ -106,7 +106,7 @@ type Decoder struct {
 
 // Init initializes the decoder.
 func (d *Decoder) Init() {
-	d.timeDecoder = rtptimedec.New(rtpClockRate)
+	d.timeDecoder = rtptime.NewDecoder(rtpClockRate)
 }
 
 // Decode decodes an image from a RTP/M-JPEG packet.

--- a/pkg/formatdecenc/rtpmpeg4audio/decoder.go
+++ b/pkg/formatdecenc/rtpmpeg4audio/decoder.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aler9/gortsplib/v2/pkg/bits"
 	"github.com/aler9/gortsplib/v2/pkg/codecs/mpeg4audio"
-	"github.com/aler9/gortsplib/v2/pkg/rtptimedec"
+	"github.com/aler9/gortsplib/v2/pkg/rtptime"
 )
 
 // ErrMorePacketsNeeded is returned when more packets are needed.
@@ -29,7 +29,7 @@ type Decoder struct {
 	// The number of bits in which the AU-Index-delta field is encoded in any non-first AU-header.
 	IndexDeltaLength int
 
-	timeDecoder    *rtptimedec.Decoder
+	timeDecoder    *rtptime.Decoder
 	firstAUParsed  bool
 	adtsMode       bool
 	fragments      [][]byte
@@ -38,7 +38,7 @@ type Decoder struct {
 
 // Init initializes the decoder.
 func (d *Decoder) Init() {
-	d.timeDecoder = rtptimedec.New(d.SampleRate)
+	d.timeDecoder = rtptime.NewDecoder(d.SampleRate)
 }
 
 // Decode decodes AUs from a RTP/MPEG4-audio packet.

--- a/pkg/formatdecenc/rtpsimpleaudio/decoder.go
+++ b/pkg/formatdecenc/rtpsimpleaudio/decoder.go
@@ -5,19 +5,19 @@ import (
 
 	"github.com/pion/rtp"
 
-	"github.com/aler9/gortsplib/v2/pkg/rtptimedec"
+	"github.com/aler9/gortsplib/v2/pkg/rtptime"
 )
 
 // Decoder is a RTP/simple audio decoder.
 type Decoder struct {
 	SampleRate int
 
-	timeDecoder *rtptimedec.Decoder
+	timeDecoder *rtptime.Decoder
 }
 
 // Init initializes the decoder.
 func (d *Decoder) Init() {
-	d.timeDecoder = rtptimedec.New(d.SampleRate)
+	d.timeDecoder = rtptime.NewDecoder(d.SampleRate)
 }
 
 // Decode decodes an audio frame from a RTP packet.

--- a/pkg/formatdecenc/rtpvp8/decoder.go
+++ b/pkg/formatdecenc/rtpvp8/decoder.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pion/rtp"
 	"github.com/pion/rtp/codecs"
 
-	"github.com/aler9/gortsplib/v2/pkg/rtptimedec"
+	"github.com/aler9/gortsplib/v2/pkg/rtptime"
 )
 
 // ErrMorePacketsNeeded is returned when more packets are needed.
@@ -23,14 +23,14 @@ var ErrNonStartingPacketAndNoPrevious = errors.New(
 
 // Decoder is a RTP/VP8 decoder.
 type Decoder struct {
-	timeDecoder         *rtptimedec.Decoder
+	timeDecoder         *rtptime.Decoder
 	firstPacketReceived bool
 	fragments           [][]byte
 }
 
 // Init initializes the decoder.
 func (d *Decoder) Init() {
-	d.timeDecoder = rtptimedec.New(rtpClockRate)
+	d.timeDecoder = rtptime.NewDecoder(rtpClockRate)
 }
 
 // Decode decodes a VP8 frame from a RTP/VP8 packet.

--- a/pkg/formatdecenc/rtpvp9/decoder.go
+++ b/pkg/formatdecenc/rtpvp9/decoder.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pion/rtp"
 	"github.com/pion/rtp/codecs"
 
-	"github.com/aler9/gortsplib/v2/pkg/rtptimedec"
+	"github.com/aler9/gortsplib/v2/pkg/rtptime"
 )
 
 // ErrMorePacketsNeeded is returned when more packets are needed.
@@ -23,14 +23,14 @@ var ErrNonStartingPacketAndNoPrevious = errors.New(
 
 // Decoder is a RTP/VP9 decoder.
 type Decoder struct {
-	timeDecoder         *rtptimedec.Decoder
+	timeDecoder         *rtptime.Decoder
 	firstPacketReceived bool
 	fragments           [][]byte
 }
 
 // Init initializes the decoder.
 func (d *Decoder) Init() {
-	d.timeDecoder = rtptimedec.New(rtpClockRate)
+	d.timeDecoder = rtptime.NewDecoder(rtpClockRate)
 }
 
 // Decode decodes a VP9 frame from a RTP/VP9 packet.

--- a/pkg/rtptime/decoder.go
+++ b/pkg/rtptime/decoder.go
@@ -1,5 +1,5 @@
-// Package rtptimedec contains a RTP timestamp decoder.
-package rtptimedec
+// Package rtptime contains a RTP timestamp decoder and encoder.
+package rtptime
 
 import (
 	"time"
@@ -15,14 +15,14 @@ type Decoder struct {
 	prev        uint32
 }
 
-// New allocates a Decoder.
-func New(clockRate int) *Decoder {
+// NewDecoder allocates a Decoder.
+func NewDecoder(clockRate int) *Decoder {
 	return &Decoder{
 		clockRate: time.Duration(clockRate),
 	}
 }
 
-// Decode decodes a RTP timestamp.
+// Decode decodes a timestamp.
 func (d *Decoder) Decode(ts uint32) time.Duration {
 	if !d.initialized {
 		d.initialized = true
@@ -42,7 +42,7 @@ func (d *Decoder) Decode(ts uint32) time.Duration {
 		d.overall += time.Duration(diff)
 	}
 
-	// avoid an int64 overflow and keep resolution by splitting division into two parts:
+	// avoid an int64 overflow and preserve resolution by splitting division into two parts:
 	// first add the integer part, then the decimal part.
 	secs := d.overall / d.clockRate
 	dec := d.overall % d.clockRate

--- a/pkg/rtptime/decoder_test.go
+++ b/pkg/rtptime/decoder_test.go
@@ -1,4 +1,4 @@
-package rtptimedec
+package rtptime
 
 import (
 	"testing"
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNegativeDiff(t *testing.T) {
-	d := New(90000)
+func TestDecoderNegativeDiff(t *testing.T) {
+	d := NewDecoder(90000)
 
 	i := uint32(0)
 	pts := d.Decode(i)
@@ -27,8 +27,8 @@ func TestNegativeDiff(t *testing.T) {
 	require.Equal(t, 3*time.Second, pts)
 }
 
-func TestOverflow(t *testing.T) {
-	d := New(90000)
+func TestDecoderOverflow(t *testing.T) {
+	d := NewDecoder(90000)
 
 	i := uint32(0xFFFFFFFF - 90000 + 1)
 	secs := time.Duration(0)
@@ -56,8 +56,8 @@ func TestOverflow(t *testing.T) {
 	}
 }
 
-func TestOverflowAndBack(t *testing.T) {
-	d := New(90000)
+func TestDecoderOverflowAndBack(t *testing.T) {
+	d := NewDecoder(90000)
 
 	pts := d.Decode(0xFFFFFFFF - 90000 + 1)
 	require.Equal(t, time.Duration(0), pts)
@@ -81,7 +81,7 @@ func TestOverflowAndBack(t *testing.T) {
 func BenchmarkDecoder(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		func() {
-			d := New(90000)
+			d := NewDecoder(90000)
 			n := uint32(0)
 			for j := 0; j < 200; j++ {
 				if (j % 2) == 0 {

--- a/pkg/rtptime/encoder.go
+++ b/pkg/rtptime/encoder.go
@@ -1,0 +1,25 @@
+package rtptime
+
+import (
+	"math"
+	"time"
+)
+
+// Encoder is a RTP timestamp encoder.
+type Encoder struct {
+	clockRate        float64
+	initialTimestamp time.Duration
+}
+
+// NewEncoder allocates an Encoder.
+func NewEncoder(clockRate int, initialTimestamp uint32) *Encoder {
+	return &Encoder{
+		clockRate:        float64(clockRate),
+		initialTimestamp: time.Duration(math.Ceil(float64(initialTimestamp) * float64(time.Second) / float64(clockRate))),
+	}
+}
+
+// Encode encodes a timestamp.
+func (e *Encoder) Encode(ts time.Duration) uint32 {
+	return uint32((e.initialTimestamp + ts).Seconds() * e.clockRate)
+}

--- a/pkg/rtptime/encoder_test.go
+++ b/pkg/rtptime/encoder_test.go
@@ -1,0 +1,14 @@
+package rtptime
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncoder(t *testing.T) {
+	e := NewEncoder(90000, 12345)
+
+	ts := e.Encode(0)
+	require.Equal(t, uint32(12345), ts)
+}


### PR DESCRIPTION
previous formula was: uint32(a + uint32(b))
this formula overflows two times, while it should overflow once. new formula is: uint32(uint64(a) + uint64(b))