### PR TITLE
Support JPEG comment markers in MJPEG encoder

### DIFF
--- a/pkg/codecs/jpeg/jpeg.go
+++ b/pkg/codecs/jpeg/jpeg.go
@@ -10,4 +10,5 @@ const (
 	MarkerStartOfFrame1           = 0xC0
 	MarkerStartOfScan             = 0xDA
 	MarkerEndOfImage              = 0xD9
+	MarkerComment                 = 0xFE
 )

--- a/pkg/formatdecenc/rtpmjpeg/encoder.go
+++ b/pkg/formatdecenc/rtpmjpeg/encoder.go
@@ -95,7 +95,8 @@ outer:
 
 		switch h1 {
 		case 0xE0, 0xE1, 0xE2, // JFIF
-			jpeg.MarkerDefineHuffmanTable:
+			jpeg.MarkerDefineHuffmanTable,
+			jpeg.MarkerComment:
 			mlen := int(image[0])<<8 | int(image[1])
 			if len(image) < mlen {
 				return nil, fmt.Errorf("image is too short")
@@ -176,13 +177,6 @@ outer:
 
 			data = image
 			break outer
-
-		case jpeg.MarkerComment:
-			mlen := int(image[0])<<8 | int(image[1])
-			if len(image) < mlen {
-				return nil, fmt.Errorf("image is too short")
-			}
-			image = image[mlen:]
 
 		default:
 			return nil, fmt.Errorf("unknown marker: 0x%.2x", h1)

--- a/pkg/formatdecenc/rtpmjpeg/encoder.go
+++ b/pkg/formatdecenc/rtpmjpeg/encoder.go
@@ -177,6 +177,13 @@ outer:
 			data = image
 			break outer
 
+		case jpeg.MarkerComment:
+			mlen := int(image[0])<<8 | int(image[1])
+			if len(image) < mlen {
+				return nil, fmt.Errorf("image is too short")
+			}
+			image = image[mlen:]
+
 		default:
 			return nil, fmt.Errorf("unknown marker: 0x%.2x", h1)
 		}


### PR DESCRIPTION
Added support for handling comment markers (0xF0) by skipping their data.