### PR TITLE
use normalized trackID in place of mediaUUID

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 
@@ -68,6 +69,12 @@ func findBaseURL(sd *sdp.SessionDescription, res *base.Response, u *url.URL) (*u
 
 	// use URL of request
 	return u, nil
+}
+
+func resetMediaControls(ms media.Medias) {
+	for _, media := range ms {
+		media.Control = "mediaUUID=" + uuid.New().String()
+	}
 }
 
 type clientState int
@@ -1118,7 +1125,7 @@ func (c *Client) doAnnounce(u *url.URL, medias media.Medias) (*base.Response, er
 		return nil, err
 	}
 
-	medias.SetControls()
+	resetMediaControls(medias)
 
 	byts, err := medias.Marshal(false).Marshal()
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -16,7 +16,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 
@@ -72,8 +71,8 @@ func findBaseURL(sd *sdp.SessionDescription, res *base.Response, u *url.URL) (*u
 }
 
 func resetMediaControls(ms media.Medias) {
-	for _, media := range ms {
-		media.Control = "mediaUUID=" + uuid.New().String()
+	for i, media := range ms {
+		media.Control = "trackID=" + strconv.FormatInt(int64(i), 10)
 	}
 }
 

--- a/client_play_test.go
+++ b/client_play_test.go
@@ -139,7 +139,7 @@ func TestClientPlayFormats(t *testing.T) {
 		require.Equal(t, mustParseURL("rtsp://localhost:8554/teststream"), req.URL)
 
 		medias := media.Medias{media1, media2, media3}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -284,7 +284,7 @@ func TestClientPlay(t *testing.T) {
 						Formats: []formats.Format{forma},
 					},
 				}
-				medias.SetControls()
+				resetMediaControls(medias)
 
 				err = conn.WriteResponse(&base.Response{
 					StatusCode: base.StatusOK,
@@ -558,7 +558,7 @@ func TestClientPlayPartial(t *testing.T) {
 				Formats: []formats.Format{forma},
 			},
 		}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -701,7 +701,7 @@ func TestClientPlayContentBase(t *testing.T) {
 				require.Equal(t, mustParseURL("rtsp://localhost:8554/teststream"), req.URL)
 
 				medias := media.Medias{testH264Media}
-				medias.SetControls()
+				resetMediaControls(medias)
 
 				switch ca {
 				case "absent":
@@ -831,7 +831,7 @@ func TestClientPlayAnyPort(t *testing.T) {
 				require.Equal(t, base.Describe, req.Method)
 
 				medias := media.Medias{testH264Media}
-				medias.SetControls()
+				resetMediaControls(medias)
 
 				err = conn.WriteResponse(&base.Response{
 					StatusCode: base.StatusOK,
@@ -985,7 +985,7 @@ func TestClientPlayAutomaticProtocol(t *testing.T) {
 			require.Equal(t, base.Describe, req.Method)
 
 			medias := media.Medias{testH264Media}
-			medias.SetControls()
+			resetMediaControls(medias)
 
 			err = conn.WriteResponse(&base.Response{
 				StatusCode: base.StatusOK,
@@ -1078,7 +1078,7 @@ func TestClientPlayAutomaticProtocol(t *testing.T) {
 			defer close(serverDone)
 
 			medias := media.Medias{testH264Media}
-			medias.SetControls()
+			resetMediaControls(medias)
 
 			func() {
 				nconn, err := l.Accept()
@@ -1258,7 +1258,7 @@ func TestClientPlayAutomaticProtocol(t *testing.T) {
 			defer close(serverDone)
 
 			medias := media.Medias{testH264Media}
-			medias.SetControls()
+			resetMediaControls(medias)
 
 			func() {
 				nconn, err := l.Accept()
@@ -1524,7 +1524,7 @@ func TestClientPlayDifferentInterleavedIDs(t *testing.T) {
 		require.Equal(t, mustParseURL("rtsp://localhost:8554/teststream"), req.URL)
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -1719,7 +1719,7 @@ func TestClientPlayRedirect(t *testing.T) {
 					}
 
 					medias := media.Medias{testH264Media}
-					medias.SetControls()
+					resetMediaControls(medias)
 
 					err = conn.WriteResponse(&base.Response{
 						StatusCode: base.StatusOK,
@@ -1880,7 +1880,7 @@ func TestClientPlayPause(t *testing.T) {
 				require.Equal(t, base.Describe, req.Method)
 
 				medias := media.Medias{testH264Media}
-				medias.SetControls()
+				resetMediaControls(medias)
 
 				err = conn.WriteResponse(&base.Response{
 					StatusCode: base.StatusOK,
@@ -2048,7 +2048,7 @@ func TestClientPlayRTCPReport(t *testing.T) {
 		require.Equal(t, base.Describe, req.Method)
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -2226,7 +2226,7 @@ func TestClientPlayErrorTimeout(t *testing.T) {
 				require.Equal(t, base.Describe, req.Method)
 
 				medias := media.Medias{testH264Media}
-				medias.SetControls()
+				resetMediaControls(medias)
 
 				err = conn.WriteResponse(&base.Response{
 					StatusCode: base.StatusOK,
@@ -2372,7 +2372,7 @@ func TestClientPlayIgnoreTCPInvalidMedia(t *testing.T) {
 		require.Equal(t, base.Describe, req.Method)
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -2495,7 +2495,7 @@ func TestClientPlaySeek(t *testing.T) {
 		require.Equal(t, base.Describe, req.Method)
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -2659,7 +2659,7 @@ func TestClientPlayKeepaliveFromSession(t *testing.T) {
 		require.Equal(t, base.Describe, req.Method)
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -2782,7 +2782,7 @@ func TestClientPlayDifferentSource(t *testing.T) {
 		require.Equal(t, mustParseURL("rtsp://localhost:8554/test/stream?param=value"), req.URL)
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -2935,7 +2935,7 @@ func TestClientPlayDecodeErrors(t *testing.T) {
 						RTPMap:     "private/90000",
 					}},
 				}}
-				medias.SetControls()
+				resetMediaControls(medias)
 
 				err = conn.WriteResponse(&base.Response{
 					StatusCode: base.StatusOK,

--- a/client_test.go
+++ b/client_test.go
@@ -106,7 +106,7 @@ func TestClientSession(t *testing.T) {
 		require.Equal(t, base.HeaderValue{"123456"}, req.Header["Session"])
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,
@@ -183,7 +183,7 @@ func TestClientAuth(t *testing.T) {
 		require.NoError(t, err)
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		err = conn.WriteResponse(&base.Response{
 			StatusCode: base.StatusOK,

--- a/pkg/media/medias.go
+++ b/pkg/media/medias.go
@@ -3,7 +3,6 @@ package media
 import (
 	"fmt"
 
-	"github.com/google/uuid"
 	psdp "github.com/pion/sdp/v3"
 
 	"github.com/bluenviron/gortsplib/v3/pkg/sdp"
@@ -62,13 +61,6 @@ func (ms Medias) Marshal(multicast bool) *sdp.SessionDescription {
 	}
 
 	return sout
-}
-
-// SetControls sets the control attribute of all medias in the list.
-func (ms Medias) SetControls() {
-	for _, media := range ms {
-		media.Control = "mediaUUID=" + uuid.New().String()
-	}
 }
 
 // FindFormat finds a certain format among all the formats in all the medias.

--- a/server_conn.go
+++ b/server_conn.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	gourl "net/url"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -36,12 +37,15 @@ func mediasForSDP(
 			Type: medi.Type,
 			// Direction: skipped for the moment
 			Formats: medi.Formats,
-			Control: "mediaUUID=" + streamMedias[medi].uuid.String(),
+			// we have to use trackID=number in order to support clients
+			// like the Grandstream GXV3500.
+			Control: "trackID=" + strconv.FormatInt(int64(i), 10),
 		}
 
 		// always use the absolute URL of the track as control attribute, in order
-		// to support GStreamer's rtspsrc. When a relative control is used, GStreamer
-		// puts it between path and query, instead of appending it to the URL.
+		// to fix compatibility between GStreamer and URLs with queries.
+		// (when a relative control is used, GStreamer puts it between path and query,
+		// instead of appending it to the URL).
 		u, _ := mc.URL(contentBase)
 		mc.Control = u.String()
 

--- a/server_play_test.go
+++ b/server_play_test.go
@@ -54,7 +54,7 @@ func multicastCapableIP(t *testing.T) string {
 
 func relativeControlAttribute(md *psdp.MediaDescription) string {
 	v, _ := md.Attribute("control")
-	i := strings.Index(v, "mediaUUID=")
+	i := strings.Index(v, "trackID=")
 	return v[i:]
 }
 
@@ -2186,7 +2186,7 @@ func TestServerPlayAdditionalInfos(t *testing.T) {
 	})
 
 	rtpInfo, ssrcs := getInfos()
-	require.True(t, strings.HasPrefix(mustParseURL((*rtpInfo)[0].URL).Path, "/teststream/mediaUUID="))
+	require.True(t, strings.HasPrefix(mustParseURL((*rtpInfo)[0].URL).Path, "/teststream/trackID="))
 	require.Equal(t, &headers.RTPInfo{
 		&headers.RTPInfoEntry{
 			URL: (&url.URL{
@@ -2221,7 +2221,7 @@ func TestServerPlayAdditionalInfos(t *testing.T) {
 	})
 
 	rtpInfo, ssrcs = getInfos()
-	require.True(t, strings.HasPrefix(mustParseURL((*rtpInfo)[0].URL).Path, "/teststream/mediaUUID="))
+	require.True(t, strings.HasPrefix(mustParseURL((*rtpInfo)[0].URL).Path, "/teststream/trackID="))
 	require.Equal(t, &headers.RTPInfo{
 		&headers.RTPInfoEntry{
 			URL: (&url.URL{

--- a/server_record_test.go
+++ b/server_record_test.go
@@ -337,7 +337,7 @@ func TestServerRecordErrorSetupMediaTwice(t *testing.T) {
 	conn := conn.NewConn(nconn)
 
 	medias := media.Medias{testH264Media}
-	medias.SetControls()
+	resetMediaControls(medias)
 
 	res, err := writeReqReadRes(conn, base.Request{
 		Method: base.Announce,
@@ -457,7 +457,7 @@ func TestServerRecordErrorRecordPartialMedias(t *testing.T) {
 			Formats: []formats.Format{forma},
 		},
 	}
-	medias.SetControls()
+	resetMediaControls(medias)
 
 	res, err := writeReqReadRes(conn, base.Request{
 		Method: base.Announce,
@@ -630,7 +630,7 @@ func TestServerRecord(t *testing.T) {
 					}},
 				},
 			}
-			medias.SetControls()
+			resetMediaControls(medias)
 
 			res, err := writeReqReadRes(conn, base.Request{
 				Method: base.Announce,
@@ -834,7 +834,7 @@ func TestServerRecordErrorInvalidProtocol(t *testing.T) {
 	conn := conn.NewConn(nconn)
 
 	medias := media.Medias{testH264Media}
-	medias.SetControls()
+	resetMediaControls(medias)
 
 	res, err := writeReqReadRes(conn, base.Request{
 		Method: base.Announce,
@@ -935,7 +935,7 @@ func TestServerRecordRTCPReport(t *testing.T) {
 	conn := conn.NewConn(nconn)
 
 	medias := media.Medias{testH264Media}
-	medias.SetControls()
+	resetMediaControls(medias)
 
 	res, err := writeReqReadRes(conn, base.Request{
 		Method: base.Announce,
@@ -1110,7 +1110,7 @@ func TestServerRecordTimeout(t *testing.T) {
 			conn := conn.NewConn(nconn)
 
 			medias := media.Medias{testH264Media}
-			medias.SetControls()
+			resetMediaControls(medias)
 
 			res, err := writeReqReadRes(conn, base.Request{
 				Method: base.Announce,
@@ -1233,7 +1233,7 @@ func TestServerRecordWithoutTeardown(t *testing.T) {
 			conn := conn.NewConn(nconn)
 
 			medias := media.Medias{testH264Media}
-			medias.SetControls()
+			resetMediaControls(medias)
 
 			res, err := writeReqReadRes(conn, base.Request{
 				Method: base.Announce,
@@ -1346,7 +1346,7 @@ func TestServerRecordUDPChangeConn(t *testing.T) {
 		conn := conn.NewConn(nconn)
 
 		medias := media.Medias{testH264Media}
-		medias.SetControls()
+		resetMediaControls(medias)
 
 		res, err := writeReqReadRes(conn, base.Request{
 			Method: base.Announce,
@@ -1504,7 +1504,7 @@ func TestServerRecordDecodeErrors(t *testing.T) {
 					RTPMap:     "private/90000",
 				}},
 			}}
-			medias.SetControls()
+			resetMediaControls(medias)
 
 			res, err := writeReqReadRes(conn, base.Request{
 				Method: base.Announce,

--- a/server_stream.go
+++ b/server_stream.go
@@ -38,8 +38,8 @@ func NewServerStream(medias media.Medias) *ServerStream {
 	}
 
 	st.streamMedias = make(map[*media.Media]*serverStreamMedia, len(medias))
-	for _, medi := range medias {
-		st.streamMedias[medi] = newServerStreamMedia(st, medi)
+	for i, medi := range medias {
+		st.streamMedias[medi] = newServerStreamMedia(st, medi, i)
 	}
 
 	return st

--- a/server_stream_media.go
+++ b/server_stream_media.go
@@ -3,7 +3,6 @@ package gortsplib
 import (
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/pion/rtcp"
 	"github.com/pion/rtp"
 
@@ -12,16 +11,16 @@ import (
 )
 
 type serverStreamMedia struct {
-	uuid            uuid.UUID
+	trackID         int
 	media           *media.Media
 	formats         map[uint8]*serverStreamFormat
 	multicastWriter *serverMulticastWriter
 }
 
-func newServerStreamMedia(st *ServerStream, medi *media.Media) *serverStreamMedia {
+func newServerStreamMedia(st *ServerStream, medi *media.Media, trackID int) *serverStreamMedia {
 	sm := &serverStreamMedia{
-		uuid:  uuid.New(),
-		media: medi,
+		trackID: trackID,
+		media:   medi,
 	}
 
 	sm.formats = make(map[uint8]*serverStreamFormat)


### PR DESCRIPTION
This is needed to support clients like the Grandstream GXV3500.

Fixes https://github.com/bluenviron/gortsplib/issues/190