### PR TITLE
fix parsing of MP4A-LATM formats with no channels and object

### DIFF
--- a/pkg/formats/format_test.go
+++ b/pkg/formats/format_test.go
@@ -295,6 +295,32 @@ var casesFormat = []struct {
 		},
 	},
 	{
+		"audio aac latm no channels",
+		"audio",
+		110,
+		"MP4A-LATM/48000",
+		map[string]string{
+			"cpresent": "0",
+			"config":   "40002310",
+		},
+		&MPEG4AudioLATM{
+			PayloadTyp:     110,
+			SampleRate:     48000,
+			Channels:       1,
+			ProfileLevelID: 30,
+			CPresent:       boolPtr(false),
+			Object:         2,
+			Config:         []byte{0x40, 0x00, 0x23, 0x10},
+		},
+		"MP4A-LATM/48000/1",
+		map[string]string{
+			"profile-level-id": "30",
+			"object":           "2",
+			"cpresent":         "0",
+			"config":           "40002310",
+		},
+	},
+	{
 		"audio vorbis",
 		"audio",
 		96,
@@ -766,14 +792,6 @@ func TestUnmarshalMPEG4AudioLATMErrors(t *testing.T) {
 
 	_, err = Unmarshal("audio", 96, "MP4A-LATM/48000/2", map[string]string{
 		"sbr-enabled": "aaa",
-	})
-	require.Error(t, err)
-
-	_, err = Unmarshal("audio", 96, "MP4A-LATM/48000/2", map[string]string{
-		"profile-level-id": "15",
-		"cpresent":         "0",
-		"config":           "400026103fc0",
-		"sbr-enabled":      "1",
 	})
 	require.Error(t, err)
 

--- a/pkg/formats/mpeg4_audio_latm.go
+++ b/pkg/formats/mpeg4_audio_latm.go
@@ -29,21 +29,22 @@ func (f *MPEG4AudioLATM) unmarshal(
 	rtpmap string, fmtp map[string]string,
 ) error {
 	tmp := strings.SplitN(clock, "/", 2)
-	if len(tmp) != 2 {
-		return fmt.Errorf("invalid clock: %v", clock)
-	}
 
-	tmp2, err := strconv.ParseInt(tmp[0], 10, 64)
+	tmp1, err := strconv.ParseInt(tmp[0], 10, 64)
 	if err != nil {
 		return err
 	}
-	f.SampleRate = int(tmp2)
+	f.SampleRate = int(tmp1)
 
-	tmp2, err = strconv.ParseInt(tmp[1], 10, 64)
-	if err != nil {
-		return err
+	if len(tmp) >= 2 {
+		tmp2, err := strconv.ParseInt(tmp[1], 10, 64)
+		if err != nil {
+			return err
+		}
+		f.Channels = int(tmp2)
+	} else {
+		f.Channels = 1
 	}
-	f.Channels = int(tmp2)
 
 	f.PayloadTyp = payloadType
 	f.ProfileLevelID = 30 // default value defined by specification
@@ -111,8 +112,9 @@ func (f *MPEG4AudioLATM) unmarshal(
 	}
 
 	if f.Object == 0 {
-		return fmt.Errorf("object is missing")
+		f.Object = 2
 	}
+
 	if f.Config == nil {
 		return fmt.Errorf("config is missing")
 	}


### PR DESCRIPTION
https://github.com/aler9/mediamtx/issues/1716