### PR TITLE
client: return an error in case of invalid packet

### DIFF
--- a/client_media.go
+++ b/client_media.go
@@ -211,6 +211,7 @@ func (cm *clientMedia) readRTPTCPPlay(payload []byte) error {
 
 	forma, ok := cm.formats[pkt.PayloadType]
 	if !ok {
+		cm.c.OnDecodeError(fmt.Errorf("received RTP packet with unknown format: %d", pkt.PayloadType))
 		return nil
 	}
 
@@ -284,7 +285,7 @@ func (cm *clientMedia) readRTPUDPPlay(payload []byte) error {
 
 	forma, ok := cm.formats[pkt.PayloadType]
 	if !ok {
-		cm.c.OnDecodeError(fmt.Errorf("received RTP packet with unknown payload type (%d)", pkt.PayloadType))
+		cm.c.OnDecodeError(fmt.Errorf("received RTP packet with unknown format: %d", pkt.PayloadType))
 		return nil
 	}
 

--- a/client_record_test.go
+++ b/client_record_test.go
@@ -1023,14 +1023,11 @@ func TestClientRecordDecodeErrors(t *testing.T) {
 				}(),
 				OnDecodeError: func(err error) {
 					switch {
-					case ca.proto == "udp" && ca.name == "rtcp invalid":
+					case ca.name == "rtcp invalid":
 						require.EqualError(t, err, "rtcp: packet too short")
 
 					case ca.proto == "udp" && ca.name == "rtcp too big":
 						require.EqualError(t, err, "RTCP packet is too big to be read with UDP")
-
-					case ca.proto == "tcp" && ca.name == "rtcp invalid":
-						require.EqualError(t, err, "rtcp: packet too short")
 
 					case ca.proto == "tcp" && ca.name == "rtcp too big":
 						require.EqualError(t, err, "RTCP packet size (2000) is greater than maximum allowed (1472)")

--- a/server_session_media.go
+++ b/server_session_media.go
@@ -194,7 +194,7 @@ func (sm *serverSessionMedia) readRTPUDPRecord(payload []byte) error {
 
 	forma, ok := sm.formats[pkt.PayloadType]
 	if !ok {
-		sm.ss.onDecodeError(fmt.Errorf("received RTP packet with unknown payload type (%d)", pkt.PayloadType))
+		sm.ss.onDecodeError(fmt.Errorf("received RTP packet with unknown format: %d", pkt.PayloadType))
 		return nil
 	}
 
@@ -273,7 +273,7 @@ func (sm *serverSessionMedia) readRTPTCPRecord(payload []byte) error {
 
 	forma, ok := sm.formats[pkt.PayloadType]
 	if !ok {
-		sm.ss.onDecodeError(fmt.Errorf("received RTP packet with unknown payload type (%d)", pkt.PayloadType))
+		sm.ss.onDecodeError(fmt.Errorf("received RTP packet with unknown format: %d", pkt.PayloadType))
 		return nil
 	}
 


### PR DESCRIPTION
when reading with TCP and packet has an unknown format.