### PR TITLE
Trim surrounding [] from uri host before join host port

### DIFF
--- a/client.go
+++ b/client.go
@@ -708,6 +708,11 @@ func (c *Client) connOpen() error {
 		return fmt.Errorf("RTSPS can be used only with TCP")
 	}
 
+	// strip the mandatory [] from IPv6 address in preparation for split or join
+	if strings.HasPrefix(c.host, "[") && strings.HasSuffix(c.host, "]") {
+		c.host = c.host[1 : len(c.host)-1]
+	}
+
 	// add default port
 	_, _, err := net.SplitHostPort(c.host)
 	if err != nil {


### PR DESCRIPTION
As is mandatory for raw IPv6 addresses in URLs, square brackets are present around the host. Strip these before attempting to split or join. If a port is present, the raw IPv6 address will not have a trailing `]`, so it will maintain the brackets.

Closes #313