### PR TITLE
Improve IPv6 support

### DIFF
--- a/pkg/url/url.go
+++ b/pkg/url/url.go
@@ -89,3 +89,18 @@ func (u *URL) RTSPPathAndQuery() (string, bool) {
 
 	return pathAndQuery, true
 }
+
+// Hostname returns u.Host, stripping any valid port number if present.
+//
+// If the result is enclosed in square brackets, as literal IPv6 addresses are,
+// the square brackets are removed from the result.
+func (u *URL) Hostname() string {
+	return (*url.URL)(u).Hostname()
+}
+
+// Port returns the port part of u.Host, without the leading colon.
+//
+// If u.Host doesn't contain a valid numeric port, Port returns an empty string.
+func (u *URL) Port() string {
+	return (*url.URL)(u).Port()
+}


### PR DESCRIPTION
This improves the handling of hosts.

This makes the following types of host a valid options:
- `[::1]`
- `::1`
- `192.168.100.1`
- `192.168.100.1:123`
- `[::1]:8080`
- `example.com`
- `example.com:8080`

Closes #313