### PR TITLE
fit some sdp has no v=0 at start

### DIFF
--- a/pkg/sdp/sdp.go
+++ b/pkg/sdp/sdp.go
@@ -677,12 +677,14 @@ func (s *SessionDescription) Unmarshal(byts []byte) error {
 			case 'v':
 				err := s.unmarshalProtocolVersion(val)
 				if err != nil {
-					return err
+					err = s.unmarshalSession(&state, key, val)
+					continue
 				}
 				state = stateSession
 
 			default:
-				return fmt.Errorf("invalid key: %c (%s)", key, line)
+				s.unmarshalSession(&state, key, val)
+				continue
 			}
 
 		case stateSession:


### PR DESCRIPTION
The received SDP example is as follows：
```sdp
m=video 0 RTP/AVP 96
a=rtpmap:96 H264/90000
a=control:trackID=0
```