### PR TITLE
fix nil url deref when handling invalid requests

### DIFF
--- a/server_conn.go
+++ b/server_conn.go
@@ -208,8 +208,13 @@ func (sc *ServerConn) handleRequestInner(req *base.Request) (*base.Response, err
 	if cseq, ok := req.Header["CSeq"]; !ok || len(cseq) != 1 {
 		return &base.Response{
 			StatusCode: base.StatusBadRequest,
-			Header:     base.Header{},
 		}, liberrors.ErrServerCSeqMissing{}
+	}
+
+	if req.Method != base.Options && req.URL == nil {
+		return &base.Response{
+			StatusCode: base.StatusBadRequest,
+		}, liberrors.ErrServerInvalidPath{}
 	}
 
 	sxID := getSessionID(req.Header)
@@ -218,12 +223,6 @@ func (sc *ServerConn) handleRequestInner(req *base.Request) (*base.Response, err
 	var query string
 	switch req.Method {
 	case base.Describe, base.GetParameter, base.SetParameter:
-		if req.URL == nil {
-			return &base.Response{
-				StatusCode: base.StatusBadRequest,
-			}, liberrors.ErrServerInvalidPath{}
-		}
-
 		pathAndQuery, ok := req.URL.RTSPPathAndQuery()
 		if !ok {
 			return &base.Response{

--- a/server_conn.go
+++ b/server_conn.go
@@ -218,6 +218,12 @@ func (sc *ServerConn) handleRequestInner(req *base.Request) (*base.Response, err
 	var query string
 	switch req.Method {
 	case base.Describe, base.GetParameter, base.SetParameter:
+		if req.URL == nil {
+			return &base.Response{
+				StatusCode: base.StatusBadRequest,
+			}, liberrors.ErrServerInvalidPath{}
+		}
+
 		pathAndQuery, ok := req.URL.RTSPPathAndQuery()
 		if !ok {
 			return &base.Response{


### PR DESCRIPTION
This fixes the following panic when handling certain invalid requests:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x50 pc=0x5601e7562614]
goroutine 206 [running]:
github.com/bluenviron/gortsplib/v4/pkg/url.(*URL).RTSPPathAndQuery(...)
        github.com/bluenviron/gortsplib/v4@v4.3.0/pkg/url/url.go:81
github.com/bluenviron/gortsplib/v4.(*ServerConn).handleRequestInner(0xc0001a8200, 0xc00064c7c0)
        github.com/bluenviron/gortsplib/v4@v4.3.0/server_conn.go:221 +0x174
github.com/bluenviron/gortsplib/v4.(*ServerConn).handleRequestOuter(0xc0001a8200, 0xc00064c7c0)
        github.com/bluenviron/gortsplib/v4@v4.3.0/server_conn.go:382 +0x67
github.com/bluenviron/gortsplib/v4.(*ServerConn).runInner(0xc0001a8200)
        github.com/bluenviron/gortsplib/v4@v4.3.0/server_conn.go:191 +0x172
github.com/bluenviron/gortsplib/v4.(*ServerConn).run(0xc0001a8200)
        github.com/bluenviron/gortsplib/v4@v4.3.0/server_conn.go:165 +0x348
created by github.com/bluenviron/gortsplib/v4.newServerConn in goroutine 7
        github.com/bluenviron/gortsplib/v4@v4.3.0/server_conn.go:109 +0x3d6
```