### PR TITLE
Workaround for Grandstream GXD3500 corrupt SETUP Digest Headers

### DIFF
--- a/pkg/auth/validate.go
+++ b/pkg/auth/validate.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/bluenviron/gortsplib/v4/pkg/base"
 	"github.com/bluenviron/gortsplib/v4/pkg/headers"
@@ -122,6 +123,12 @@ func Validate(
 
 		if *auth.DigestValues.Username != user {
 			return fmt.Errorf("authentication failed")
+		}
+
+		// Workaroud for Grandstream GXD3500
+		userAgent, exists := req.Header["User-Agent"]
+		if exists && strings.HasPrefix(userAgent[0], "Grandstream") && req.Method == "SETUP" {
+			return nil // Grandstrem SETUP sends invalid Digest Data, and probably does for PLAY too. Ignore it
 		}
 
 		ur := req.URL


### PR DESCRIPTION
This Pull Request goes with an Issue Report I raised on MediaMTX.
The Grandstream RTSP Decoder is buggy.
When in Basic Auth mode in MediaMTX, Grandstream start sending unexpected Digest Headers for RTSP SETUP.
When in Digest Auth mode in MediaMTX, Grandstream send a Digest Auth Header for RTSP SETUP but the computed Hash does not match the Header Response.

The only fix I've been able to come up with is to ignore Digest Auth on SETUP for Grandstream devices.
We still need to get through DESCRIBE so the client has to authenticate to get past that stage so I do not feel that this lowers security.