### PR TITLE
Fix panic on PacketNTP when format closed rtcpReceiver

### DIFF
--- a/client.go
+++ b/client.go
@@ -1890,6 +1890,9 @@ func (c *Client) PacketPTS(medi *description.Media, pkt *rtp.Packet) (time.Durat
 func (c *Client) PacketNTP(medi *description.Media, pkt *rtp.Packet) (time.Time, bool) {
 	cm := c.medias[medi]
 	ct := cm.formats[pkt.PayloadType]
+	if ct.rtcpReceiver == nil {
+		return time.Time{}, false
+	}
 	return ct.rtcpReceiver.PacketNTP(pkt.Timestamp)
 }
 


### PR DESCRIPTION
I experienced a panic inside `PacketNTP` because `rtcpReceiver` was `nil`. I think this is the result of the `clientFormat` closing the `rtcpReceiver` while there are still packets being processed. This change should prevent the panic.

![image](https://github.com/bluenviron/gortsplib/assets/8008227/cff995d9-6524-4d48-8720-0207cb04203f)
This is the crash we've seen 3 times in the last 24 hours on a device that handles 5 streams.
