### PR TITLE
Fix mjpeg type 0 check

### DIFF
--- a/pkg/format/rtpmjpeg/encoder.go
+++ b/pkg/format/rtpmjpeg/encoder.go
@@ -187,7 +187,7 @@ outer:
 		return nil, fmt.Errorf("SOF not found")
 	}
 
-	if sof.Type != 1 {
+	if sof.Type > 63 {
 		return nil, fmt.Errorf("JPEG type %d is not supported", sof.Type)
 	}
 

--- a/pkg/format/rtpmjpeg/header_jpeg.go
+++ b/pkg/format/rtpmjpeg/header_jpeg.go
@@ -22,7 +22,7 @@ func (h *headerJPEG) unmarshal(byts []byte) (int, error) {
 	h.FragmentOffset = uint32(byts[1])<<16 | uint32(byts[2])<<8 | uint32(byts[3])
 
 	h.Type = byts[4]
-	if h.Type != 1 {
+	if h.Type != 0 && h.Type != 1 {
 		return 0, fmt.Errorf("type %d is not supported", h.Type)
 	}
 

--- a/pkg/format/rtpmjpeg/header_jpeg.go
+++ b/pkg/format/rtpmjpeg/header_jpeg.go
@@ -22,7 +22,7 @@ func (h *headerJPEG) unmarshal(byts []byte) (int, error) {
 	h.FragmentOffset = uint32(byts[1])<<16 | uint32(byts[2])<<8 | uint32(byts[3])
 
 	h.Type = byts[4]
-	if h.Type != 0 && h.Type != 1 {
+	if h.Type > 63 {
 		return 0, fmt.Errorf("type %d is not supported", h.Type)
 	}
 


### PR DESCRIPTION
Type 0 corresponds to YUV 4:2:2. Since this header is passed directly to the JPEG header, no additional changes are necessary for support. See the type field here: https://datatracker.ietf.org/doc/html/rfc2435#section-4.1

I have a stream producing YUV 4:2:2 mjpeg over RTSP and have confirmed manually that piping this through ffmpeg as a jpeg decoder results in correct decoding.