### PR TITLE
Error counter

### DIFF
--- a/client.go
+++ b/client.go
@@ -251,6 +251,10 @@ type Client struct {
 	BytesReceived *uint64
 	// pointer to a variable that stores sent bytes.
 	BytesSent *uint64
+	// pointer to a variable that stores read errors.
+	ReadErrors *uint64
+	// pointer to a variable that stores write errors.
+	WriteErrors *uint64
 
 	//
 	// system functions (all optional)
@@ -365,6 +369,12 @@ func (c *Client) Start(scheme string, host string) error {
 	}
 	if c.BytesSent == nil {
 		c.BytesSent = new(uint64)
+	}
+	if c.ReadErrors == nil {
+		c.ReadErrors = new(uint64)
+	}
+	if c.WriteErrors == nil {
+		c.WriteErrors = new(uint64)
 	}
 
 	// system functions
@@ -882,7 +892,7 @@ func (c *Client) connOpen() error {
 	}
 
 	c.nconn = nconn
-	bc := bytecounter.New(c.nconn, c.BytesReceived, c.BytesSent)
+	bc := bytecounter.New(c.nconn, c.BytesReceived, c.BytesSent, c.ReadErrors, c.WriteErrors)
 	c.conn = conn.NewConn(bc)
 	c.reader = &clientReader{
 		c: c,

--- a/pkg/bytecounter/bytecounter.go
+++ b/pkg/bytecounter/bytecounter.go
@@ -1,4 +1,4 @@
-// Package bytecounter contains a io.ReadWriter wrapper that allows to count read and written bytes.
+// Package bytecounter contains a io.ReadWriter wrapper that allows to count read and written bytes, and the number of errors.
 package bytecounter
 
 import (
@@ -6,40 +6,60 @@ import (
 	"sync/atomic"
 )
 
-// ByteCounter is a io.ReadWriter wrapper that allows to count read and written bytes.
+// ByteCounter is a io.ReadWriter wrapper that allows to count read and written bytes and errors.
 type ByteCounter struct {
 	rw       io.ReadWriter
 	received *uint64
 	sent     *uint64
+
+	readErrors  *uint64
+	writeErrors *uint64
 }
 
 // New allocates a ByteCounter.
-func New(rw io.ReadWriter, received *uint64, sent *uint64) *ByteCounter {
+func New(rw io.ReadWriter, received *uint64, sent *uint64, readErrors *uint64, writeErrors *uint64) *ByteCounter {
 	if received == nil {
 		received = new(uint64)
 	}
 	if sent == nil {
 		sent = new(uint64)
 	}
+	if readErrors == nil {
+		readErrors = new(uint64)
+	}
+	if writeErrors == nil {
+		writeErrors = new(uint64)
+	}
 
 	return &ByteCounter{
-		rw:       rw,
-		received: received,
-		sent:     sent,
+		rw:          rw,
+		received:    received,
+		sent:        sent,
+		readErrors:  readErrors,
+		writeErrors: writeErrors,
 	}
 }
 
 // Read implements io.ReadWriter.
 func (bc *ByteCounter) Read(p []byte) (int, error) {
 	n, err := bc.rw.Read(p)
-	atomic.AddUint64(bc.received, uint64(n))
+	if err == nil {
+		atomic.AddUint64(bc.received, uint64(n))
+	} else {
+		atomic.AddUint64(bc.readErrors, 1)
+	}
+
 	return n, err
 }
 
 // Write implements io.ReadWriter.
 func (bc *ByteCounter) Write(p []byte) (int, error) {
 	n, err := bc.rw.Write(p)
-	atomic.AddUint64(bc.sent, uint64(n))
+	if err == nil {
+		atomic.AddUint64(bc.sent, uint64(n))
+	} else {
+		atomic.AddUint64(bc.writeErrors, 1)
+	}
 	return n, err
 }
 
@@ -51,4 +71,14 @@ func (bc *ByteCounter) BytesReceived() uint64 {
 // BytesSent returns the number of bytes sent.
 func (bc *ByteCounter) BytesSent() uint64 {
 	return atomic.LoadUint64(bc.sent)
+}
+
+// ReadErrors returns the number of read errors.
+func (bc *ByteCounter) ReadErrors() uint64 {
+	return atomic.LoadUint64(bc.readErrors)
+}
+
+// WriteErrors returns the number of write errors.
+func (bc *ByteCounter) WriteErrors() uint64 {
+	return atomic.LoadUint64(bc.writeErrors)
 }

--- a/pkg/bytecounter/bytecounter.go
+++ b/pkg/bytecounter/bytecounter.go
@@ -8,10 +8,14 @@ import (
 
 // ByteCounter is a io.ReadWriter wrapper that allows to count read and written bytes and errors.
 type ByteCounter struct {
-	rw       io.ReadWriter
+	rw io.ReadWriter
+
+	// These counters track total number of bytes read/written using the .Read() and .Write() methods.
+	// Only bytes that are successfully read/written are counted.
 	received *uint64
 	sent     *uint64
 
+	// These counters track the number errors that occurred during read/write operations.
 	readErrors  *uint64
 	writeErrors *uint64
 }

--- a/pkg/bytecounter/bytecounter_test.go
+++ b/pkg/bytecounter/bytecounter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestByteCounter(t *testing.T) {
-	bc := New(bytes.NewBuffer(nil), nil, nil)
+	bc := New(bytes.NewBuffer(nil), nil, nil, nil, nil)
 
 	_, err := bc.Write([]byte{0x01, 0x02, 0x03, 0x04})
 	require.NoError(t, err)

--- a/server_conn.go
+++ b/server_conn.go
@@ -89,7 +89,7 @@ func (sc *ServerConn) initialize() {
 		sc.nconn = tls.Server(sc.nconn, sc.s.TLSConfig)
 	}
 
-	sc.bc = bytecounter.New(sc.nconn, nil, nil)
+	sc.bc = bytecounter.New(sc.nconn, nil, nil, nil, nil)
 	sc.ctx = ctx
 	sc.ctxCancel = ctxCancel
 	sc.remoteAddr = sc.nconn.RemoteAddr().(*net.TCPAddr)
@@ -120,6 +120,14 @@ func (sc *ServerConn) BytesReceived() uint64 {
 // BytesSent returns the number of written bytes.
 func (sc *ServerConn) BytesSent() uint64 {
 	return sc.bc.BytesSent()
+}
+
+func (sc *ServerConn) WriteErrors() uint64 {
+	return sc.bc.WriteErrors()
+}
+
+func (sc *ServerConn) ReadErrors() uint64 {
+	return sc.bc.ReadErrors()
 }
 
 // SetUserData sets some user data associated with the connection.


### PR DESCRIPTION
* New: Add a counter for errors that occur during read/write operations. 
* Change: Only count bytes as 'written' when the bytes were sent without error

Errors are dropped getting dropped here:
https://github.com/bluenviron/gortsplib/blob/c465264fec9e81ae5f684485fe095176a88ee604/client_media.go#L169
and we would like to keep track of errors. 

We want to track errors because in some cases, when device network connectivity changes, we see situations where gortsplib client keeps a connection still open, while the gortsplib server has already closed the connection. In these situations all packet writes result in an error. Exposing an error count seems like the simplest solution to detect and act on these situations. 