### PR TITLE
Include "undefined" payload types in dynamic case

### DIFF
--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -88,7 +88,9 @@ func Unmarshal(mediaType string, payloadType uint8, rtpMap string, fmtp map[stri
 		* dynamic payload types
 		**/
 
-		case payloadType >= 96 && payloadType <= 127:
+		// Some cameras use payload types in the "undefined" ranges of 35-71 and 77-95,
+		// so include those along with the "dynamic" range of 96-127.
+		case (payloadType >= 35 && payloadType <= 71) || (payloadType >= 77 && payloadType <= 127):
 			switch {
 			// video
 


### PR DESCRIPTION
This also cameras with non-standard payload types to still be used.