### PR TITLE
fix generating media URL with leading slash in control attribute (bluenviron/mediamtx#3517)

### DIFF
--- a/pkg/description/media.go
+++ b/pkg/description/media.go
@@ -268,7 +268,7 @@ func (m Media) URL(contentBase *base.URL) (*base.URL, error) {
 	// if there's a query, insert it after the query
 	// otherwise insert it after the path
 	strURL := contentBase.String()
-	if m.Control[0] != '?' && !strings.HasSuffix(strURL, "/") {
+	if m.Control[0] != '?' && m.Control[0] != '/' && !strings.HasSuffix(strURL, "/") {
 		strURL += "/"
 	}
 

--- a/pkg/description/media_test.go
+++ b/pkg/description/media_test.go
@@ -55,6 +55,16 @@ func TestMediaURL(t *testing.T) {
 			mustParseURL("rtsps://myuser:mypass@192.168.1.99:554/path/trackID=7"),
 		},
 		{
+			"absolute control, base url no trailing slash",
+			[]byte("v=0\r\n" +
+				"s= \r\n" +
+				"m=video 0 RTP/AVP 96\r\n" +
+				"a=rtpmap:96 H264/90000\r\n" +
+				"a=control:/test"),
+			mustParseURL("rtsp://myuser:mypass@192.168.1.99:554"),
+			mustParseURL("rtsp://myuser:mypass@192.168.1.99:554/test"),
+		},
+		{
 			"relative control",
 			[]byte("v=0\r\n" +
 				"s= \r\n" +


### PR DESCRIPTION
 If the control value is the full path beginning with a `/` and the base does not end in a slash an extra slash will be added.

related to this [issue](https://github.com/bluenviron/mediamtx/issues/3517) on mediamtx