### PR TITLE
630 - Add media type payload unassigned number 35 in format

### DIFF
--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -144,6 +144,9 @@ func Unmarshal(md *psdp.MediaDescription, payloadTypeStr string) (Format, error)
 		case payloadType == 33:
 			return &MPEGTS{}
 
+		case payloadType == 35 && codec == "h264" && clock == "90000": // Bosch cameras
+			return &H264{}
+
 		// audio
 
 		case payloadType == 14:
@@ -160,10 +163,9 @@ func Unmarshal(md *psdp.MediaDescription, payloadTypeStr string) (Format, error)
 
 		/*
 		* dynamic payload types
-		* 35 (unassigned payload type) - bosch rstp particularity on dsp media
 		**/
 
-		case payloadType == 35, payloadType >= 96 && payloadType <= 127:
+		case payloadType >= 96 && payloadType <= 127:
 			switch {
 			// video
 

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -160,9 +160,10 @@ func Unmarshal(md *psdp.MediaDescription, payloadTypeStr string) (Format, error)
 
 		/*
 		* dynamic payload types
+		* 35 (unassigned payload type) - bosch rstp particularity on dsp media
 		**/
 
-		case payloadType >= 96 && payloadType <= 127:
+		case payloadType == 35, payloadType >= 96 && payloadType <= 127:
 			switch {
 			// video
 

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -928,6 +928,39 @@ var casesFormat = []struct {
 		},
 	},
 	{
+		"video h264 bosch (issue gortsplib/632)",
+		"v=0\n" +
+			"o=- 0 0 IN IP4 10.100.14.102\n" +
+			"s=LIVE VIEW\n" +
+			"c=IN IP4 0.0.0.0\n" +
+			"t=0 0\n" +
+			"a=control:rtsp://10.100.14.102:554/?inst=2&h26x=4\n" +
+			"m=video 0 RTP/AVP 35\n" +
+			"a=rtpmap:35 H264/90000\n" +
+			"a=control:rtsp://10.100.14.102:554/?inst=2&h26x=4&stream=video\n" +
+			"a=recvonly\n" +
+			"a=fmtp:35 packetization-mode=1;profile-level-id=4d4029;sprop-parameter-sets=Z01AKY2NYDwBE/LgLcBDQECA,aO44gA==\n",
+		&H264{
+			PayloadTyp: 35,
+			SPS: []byte{
+				0x67, 0x4d, 0x40, 0x29, 0x8d, 0x8d, 0x60, 0x3c,
+				0x01, 0x13, 0xf2, 0xe0, 0x2d, 0xc0, 0x43, 0x40,
+				0x40, 0x80,
+			},
+			PPS: []byte{
+				0x68, 0xee, 0x38, 0x80,
+			},
+			PacketizationMode: 1,
+		},
+		35,
+		"H264/90000",
+		map[string]string{
+			"packetization-mode":   "1",
+			"profile-level-id":     "4D4029",
+			"sprop-parameter-sets": "Z01AKY2NYDwBE/LgLcBDQECA,aO44gA==",
+		},
+	},
+	{
 		"video h265",
 		"v=0\n" +
 			"s=\n" +
@@ -1152,39 +1185,6 @@ var casesFormat = []struct {
 		95,
 		"TP-LINK/90000",
 		nil,
-	},
-	{
-		"bosch video h264",
-		"v=0\n" +
-			"o=- 0 0 IN IP4 10.100.14.102\n" +
-			"s=LIVE VIEW\n" +
-			"c=IN IP4 0.0.0.0\n" +
-			"t=0 0\n" +
-			"a=control:rtsp://10.100.14.102:554/?inst=2&h26x=4\n" +
-			"m=video 0 RTP/AVP 35\n" +
-			"a=rtpmap:35 H264/90000\n" +
-			"a=control:rtsp://10.100.14.102:554/?inst=2&h26x=4&stream=video\n" +
-			"a=recvonly\n" +
-			"a=fmtp:35 packetization-mode=1;profile-level-id=4d4029;sprop-parameter-sets=Z01AKY2NYDwBE/LgLcBDQECA,aO44gA==\n",
-		&H264{
-			PayloadTyp: 35,
-			SPS: []byte{
-				0x67, 0x4d, 0x40, 0x29, 0x8d, 0x8d, 0x60, 0x3c,
-				0x01, 0x13, 0xf2, 0xe0, 0x2d, 0xc0, 0x43, 0x40,
-				0x40, 0x80,
-			},
-			PPS: []byte{
-				0x68, 0xee, 0x38, 0x80,
-			},
-			PacketizationMode: 1,
-		},
-		35,
-		"H264/90000",
-		map[string]string{
-			"packetization-mode":   "1",
-			"profile-level-id":     "4D4029",
-			"sprop-parameter-sets": "Z01AKY2NYDwBE/LgLcBDQECA,aO44gA==",
-		},
 	},
 }
 

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -1153,6 +1153,39 @@ var casesFormat = []struct {
 		"TP-LINK/90000",
 		nil,
 	},
+	{
+		"bosch video h264",
+		"v=0\n" +
+			"o=- 0 0 IN IP4 10.100.14.102\n" +
+			"s=LIVE VIEW\n" +
+			"c=IN IP4 0.0.0.0\n" +
+			"t=0 0\n" +
+			"a=control:rtsp://10.100.14.102:554/?inst=2&h26x=4\n" +
+			"m=video 0 RTP/AVP 35\n" +
+			"a=rtpmap:35 H264/90000\n" +
+			"a=control:rtsp://10.100.14.102:554/?inst=2&h26x=4&stream=video\n" +
+			"a=recvonly\n" +
+			"a=fmtp:35 packetization-mode=1;profile-level-id=4d4029;sprop-parameter-sets=Z01AKY2NYDwBE/LgLcBDQECA,aO44gA==\n",
+		&H264{
+			PayloadTyp: 35,
+			SPS: []byte{
+				0x67, 0x4d, 0x40, 0x29, 0x8d, 0x8d, 0x60, 0x3c,
+				0x01, 0x13, 0xf2, 0xe0, 0x2d, 0xc0, 0x43, 0x40,
+				0x40, 0x80,
+			},
+			PPS: []byte{
+				0x68, 0xee, 0x38, 0x80,
+			},
+			PacketizationMode: 1,
+		},
+		35,
+		"H264/90000",
+		map[string]string{
+			"packetization-mode":   "1",
+			"profile-level-id":     "4D4029",
+			"sprop-parameter-sets": "Z01AKY2NYDwBE/LgLcBDQECA,aO44gA==",
+		},
+	},
 }
 
 func TestUnmarshal(t *testing.T) {


### PR DESCRIPTION
Media type payload unassigned number 35 is being evaluated as media type payload dynamic range (96-127).  Added some tests to verify these new changes on format_test

Currently, the video surveillance cameras of the bosch security branch offer rtsp with some peculiarities over the standard.
Instead of using the convenience media payload, which is usually 96, they use 35. This means that the camera format is not detected correctly.
This happens at least for the model FLEXIDOME IP starlight 8000i - 7.62.0003 (03500762)
There is an initial note on the first page of the document (manual) on how to use RTSP protocol in Bosch VIP cameras where it is specified that they use payload type 35 (https://community.boschsecurity.com/varuj77995/attachments/varuj77995/bt_community-tkb-video/241/1/RTSP%20usage%20with%20Bosch%20Video%20IP%20Devices.pdf). 

The two examples of SDP extracted from the camera are:
* SDP Just h264
```
v=0
o=- 0 0 IN IP4 10.100.14.102
s=LIVE VIEW
c=IN IP4 0.0.0.0
t=0 0
a=control:rtsp://10.100.14.102:554/?inst=2&h26x=4
m=video 0 RTP/AVP 35
a=rtpmap:35 H264/90000
a=control:rtsp://10.100.14.102:554/?inst=2&h26x=4&stream=video
a=recvonly
a=fmtp:35 packetization-mode=1;profile-level-id=4d4029;sprop-parameter-sets=Z01AKY2NYDwBE/LgLcBDQECA,aO44gA==
```
* SDP for h264 and h265
```
v=0
o=- 0 0 IN IP4 10.100.14.102
s=LIVE VIEW
c=IN IP4 0.0.0.0
t=0 0
a=control:rtsp://10.100.14.102:554/?inst=1
m=video 0 RTP/AVP 35
a=rtpmap:35 H264/90000
a=rtpmap:102 H265/90000
a=control:rtsp://10.100.14.102:554/?inst=1&stream=video
a=recvonly
a=fmtp:35 packetization-mode=1;profile-level-id=4d4033;sprop-parameter-sets=Z01AM42NYB4AIfYC3AQ0BAg=,aO44gA==
```

**Note**: We already have some test on sdp_test.go with these examples but they are not uploaded, you may require them if you like
