### PR TITLE
Skip invalid bytes in connection read

### DIFF
--- a/pkg/conn/conn.go
+++ b/pkg/conn/conn.go
@@ -31,20 +31,36 @@ func NewConn(rw io.ReadWriter) *Conn {
 
 // Read reads a Request, a Response or an Interleaved frame.
 func (c *Conn) Read() (interface{}, error) {
-	byts, err := c.br.Peek(2)
-	if err != nil {
-		return nil, err
-	}
+	for {
+		byts, err := c.br.Peek(2)
+		if err != nil {
+			return nil, err
+		}
 
-	if byts[0] == base.InterleavedFrameMagicByte {
-		return c.ReadInterleavedFrame()
-	}
+		if byts[0] == base.InterleavedFrameMagicByte {
+			return c.ReadInterleavedFrame()
+		}
 
-	if byts[0] == 'R' && byts[1] == 'T' {
-		return c.ReadResponse()
-	}
+		if byts[0] == 'R' && byts[1] == 'T' {
+			return c.ReadResponse()
+		}
 
-	return c.ReadRequest()
+		if (byts[0] == 'A' && byts[1] == 'N') ||
+			(byts[0] == 'D' && byts[1] == 'E') ||
+			(byts[0] == 'G' && byts[1] == 'E') ||
+			(byts[0] == 'O' && byts[1] == 'P') ||
+			(byts[0] == 'P' && byts[1] == 'A') ||
+			(byts[0] == 'P' && byts[1] == 'L') ||
+			(byts[0] == 'R' && byts[1] == 'E') ||
+			(byts[0] == 'S' && byts[1] == 'E') ||
+			(byts[0] == 'T' && byts[1] == 'E') {
+			return c.ReadRequest()
+		}
+
+		if _, err := c.br.Discard(1); err != nil {
+			return nil, err
+		}
+	}
 }
 
 // ReadRequest reads a Request.


### PR DESCRIPTION
Updates the connection reading to skip invalid bytes and probes for the interleaved frame/request/response magic bytes.

gortsplib currently dies when trying to play this whereas ffmpeg and VLC are both able to skip over invalid bytes and continue decoding. This change updates the logic so gortsplib mirrors the ffmpeg/VLC behavior.

Context: I am working with this camera https://www.axis.com/products/canon-vb-h47 which seems to throw this error on RTSP play:

```
buffer length exceeds 64
```

I traced it down to some weird packet behavior from the camera, specifically it seems to send:


```
[interleaved frame][random garbage bytes][another interleaved frame]
```

I suspect that the random garbage bytes are some corrupted interleaved frame that's missing the header. I do not know why.

Packet capture from gortsplib here if you are curious: [axis.pcap.gz](https://github.com/user-attachments/files/18065557/axis.pcap.gz)

The end of the interleaved frame has these garbage bytes:

![image](https://github.com/user-attachments/assets/ecad557d-3e90-4c55-977d-26a8bef3ece8)

after which gortsplib errors and a TEARDOWN is sent.