### PR TITLE
client: fix BytesSent / BytesReceived computation (#612)

### DIFF
--- a/client_media.go
+++ b/client_media.go
@@ -153,24 +153,20 @@ func (cm *clientMedia) findFormatWithSSRC(ssrc uint32) *clientFormat {
 }
 
 func (cm *clientMedia) writePacketRTPInQueueUDP(payload []byte) {
-	atomic.AddUint64(cm.c.BytesSent, uint64(len(payload)))
 	cm.udpRTPListener.write(payload) //nolint:errcheck
 }
 
 func (cm *clientMedia) writePacketRTCPInQueueUDP(payload []byte) {
-	atomic.AddUint64(cm.c.BytesSent, uint64(len(payload)))
 	cm.udpRTCPListener.write(payload) //nolint:errcheck
 }
 
 func (cm *clientMedia) writePacketRTPInQueueTCP(payload []byte) {
-	atomic.AddUint64(cm.c.BytesSent, uint64(len(payload)))
 	cm.tcpRTPFrame.Payload = payload
 	cm.c.nconn.SetWriteDeadline(time.Now().Add(cm.c.WriteTimeout))
 	cm.c.conn.WriteInterleavedFrame(cm.tcpRTPFrame, cm.tcpBuffer) //nolint:errcheck
 }
 
 func (cm *clientMedia) writePacketRTCPInQueueTCP(payload []byte) {
-	atomic.AddUint64(cm.c.BytesSent, uint64(len(payload)))
 	cm.tcpRTCPFrame.Payload = payload
 	cm.c.nconn.SetWriteDeadline(time.Now().Add(cm.c.WriteTimeout))
 	cm.c.conn.WriteInterleavedFrame(cm.tcpRTCPFrame, cm.tcpBuffer) //nolint:errcheck
@@ -264,8 +260,6 @@ func (cm *clientMedia) readRTCPTCPRecord(payload []byte) bool {
 func (cm *clientMedia) readRTPUDPPlay(payload []byte) bool {
 	plen := len(payload)
 
-	atomic.AddUint64(cm.c.BytesReceived, uint64(plen))
-
 	if plen == (udpMaxPayloadSize + 1) {
 		cm.c.OnDecodeError(liberrors.ErrClientRTPPacketTooBigUDP{})
 		return false
@@ -292,8 +286,6 @@ func (cm *clientMedia) readRTPUDPPlay(payload []byte) bool {
 func (cm *clientMedia) readRTCPUDPPlay(payload []byte) bool {
 	now := cm.c.timeNow()
 	plen := len(payload)
-
-	atomic.AddUint64(cm.c.BytesReceived, uint64(plen))
 
 	if plen == (udpMaxPayloadSize + 1) {
 		cm.c.OnDecodeError(liberrors.ErrClientRTCPPacketTooBigUDP{})
@@ -326,8 +318,6 @@ func (cm *clientMedia) readRTPUDPRecord(_ []byte) bool {
 
 func (cm *clientMedia) readRTCPUDPRecord(payload []byte) bool {
 	plen := len(payload)
-
-	atomic.AddUint64(cm.c.BytesReceived, uint64(plen))
 
 	if plen == (udpMaxPayloadSize + 1) {
 		cm.c.OnDecodeError(liberrors.ErrClientRTCPPacketTooBigUDP{})

--- a/client_play_test.go
+++ b/client_play_test.go
@@ -544,6 +544,11 @@ func TestClientPlay(t *testing.T) {
 			require.NoError(t, err)
 
 			<-packetRecv
+
+			require.Greater(t, atomic.LoadUint64(c.BytesSent), uint64(620))
+			require.Less(t, atomic.LoadUint64(c.BytesSent), uint64(850))
+			require.Greater(t, atomic.LoadUint64(c.BytesReceived), uint64(580))
+			require.Less(t, atomic.LoadUint64(c.BytesReceived), uint64(650))
 		})
 	}
 }

--- a/client_record_test.go
+++ b/client_record_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -334,6 +335,12 @@ func TestClientRecordSerial(t *testing.T) {
 			require.NoError(t, err)
 
 			<-recvDone
+
+			require.Greater(t, atomic.LoadUint64(c.BytesSent), uint64(730))
+			require.Less(t, atomic.LoadUint64(c.BytesSent), uint64(760))
+			require.Greater(t, atomic.LoadUint64(c.BytesReceived), uint64(180))
+			require.Less(t, atomic.LoadUint64(c.BytesReceived), uint64(210))
+
 			c.Close()
 			<-done
 

--- a/client_udp_listener.go
+++ b/client_udp_listener.go
@@ -173,6 +173,8 @@ func (u *clientUDPListener) run() {
 		now := u.c.timeNow()
 		atomic.StoreInt64(u.lastPacketTime, now.Unix())
 
+		atomic.AddUint64(u.c.BytesReceived, uint64(n))
+
 		if u.readFunc(buf[:n]) {
 			createNewBuffer()
 		}
@@ -180,6 +182,8 @@ func (u *clientUDPListener) run() {
 }
 
 func (u *clientUDPListener) write(payload []byte) error {
+	atomic.AddUint64(u.c.BytesSent, uint64(len(payload)))
+
 	// no mutex is needed here since Write() has an internal lock.
 	// https://github.com/golang/go/issues/27203#issuecomment-534386117
 	u.pc.SetWriteDeadline(time.Now().Add(u.c.WriteTimeout))

--- a/server_record_test.go
+++ b/server_record_test.go
@@ -544,13 +544,23 @@ func TestServerRecord(t *testing.T) {
 					onConnOpen: func(_ *ServerHandlerOnConnOpenCtx) {
 						close(nconnOpened)
 					},
-					onConnClose: func(_ *ServerHandlerOnConnCloseCtx) {
+					onConnClose: func(ctx *ServerHandlerOnConnCloseCtx) {
+						require.Greater(t, ctx.Conn.BytesSent(), uint64(510))
+						require.Less(t, ctx.Conn.BytesSent(), uint64(560))
+						require.Greater(t, ctx.Conn.BytesReceived(), uint64(1000))
+						require.Less(t, ctx.Conn.BytesReceived(), uint64(1200))
+
 						close(nconnClosed)
 					},
 					onSessionOpen: func(_ *ServerHandlerOnSessionOpenCtx) {
 						close(sessionOpened)
 					},
-					onSessionClose: func(_ *ServerHandlerOnSessionCloseCtx) {
+					onSessionClose: func(ctx *ServerHandlerOnSessionCloseCtx) {
+						require.Greater(t, ctx.Session.BytesSent(), uint64(75))
+						require.Less(t, ctx.Session.BytesSent(), uint64(130))
+						require.Greater(t, ctx.Session.BytesReceived(), uint64(70))
+						require.Less(t, ctx.Session.BytesReceived(), uint64(80))
+
 						close(sessionClosed)
 					},
 					onAnnounce: func(_ *ServerHandlerOnAnnounceCtx) (*base.Response, error) {


### PR DESCRIPTION
Fixes #612

When the TCP transport protocol is in use, BytesSent and BytesReceived were increased twice.