### PR TITLE
fix: empty u.path, cause 'panic: runtime error: slice bounds out of r…

### DIFF
--- a/server_session.go
+++ b/server_session.go
@@ -71,6 +71,10 @@ func getPathAndQueryAndTrackID(u *base.URL) (string, string, string, error) {
 		return path, query, trackID, nil
 	}
 
+    if u.Path == "" {
+         return "", "", "", liberrors.ErrServerPathNoSlash{}
+    }
+
 	// no track ID and a trailing slash.
 	// this happens when trying to read a MPEG-TS stream with FFmpeg.
 	if strings.HasSuffix(u.RawQuery, "/") {

--- a/server_session.go
+++ b/server_session.go
@@ -71,9 +71,9 @@ func getPathAndQueryAndTrackID(u *base.URL) (string, string, string, error) {
 		return path, query, trackID, nil
 	}
 
-    if u.Path == "" {
-         return "", "", "", liberrors.ErrServerPathNoSlash{}
-    }
+	if u.Path == "" {
+		return "", "", "", liberrors.ErrServerPathNoSlash{}
+	}
 
 	// no track ID and a trailing slash.
 	// this happens when trying to read a MPEG-TS stream with FFmpeg.


### PR DESCRIPTION
I use mediamtx 

when play with VLC  `rtsp://@127.0.0.1:8554`
<img width="943" alt="image" src="https://github.com/user-attachments/assets/18c5764b-7d64-41c1-9d4c-0556710684bd" />
```bash
panic: runtime error: slice bounds out of range [1:0]

goroutine 8 [running]:
github.com/bluenviron/gortsplib/v4.getPathAndQueryAndTrackID(0xc000554090)
	/Users/sato/go/pkg/mod/github.com/bluenviron/gortsplib/v4@v4.11.2/server_session.go:80 +0x30b
github.com/bluenviron/gortsplib/v4.(*ServerSession).handleRequestInner(0xc0003aa280, 0xc0005d2900, 0xc0000c6180)
	/Users/sato/go/pkg/mod/github.com/bluenviron/gortsplib/v4@v4.11.2/server_session.go:684 +0x1345
github.com/bluenviron/gortsplib/v4.(*ServerSession).runInner(0xc0003aa280)
	/Users/sato/go/pkg/mod/github.com/bluenviron/gortsplib/v4@v4.11.2/server_session.go:449 +0x2f5
github.com/bluenviron/gortsplib/v4.(*ServerSession).run(0xc0003aa280)
	/Users/sato/go/pkg/mod/github.com/bluenviron/gortsplib/v4@v4.11.2/server_session.go:402 +0x10f
created by github.com/bluenviron/gortsplib/v4.(*ServerSession).initialize in goroutine 25

```
ffplay is ok
```bash
ffplay -i rtsp://@127.0.0.1:8554
[tcp @ 0x7fe1a7004e40] Connection to tcp://127.0.0.1:8554?timeout=0 failed: Connection refused
rtsp://@127.0.0.1:8554: Connection refused 
```