### PR TITLE
Fix writer nullpointer panic on network reconnect

### DIFF
--- a/async_processor_test.go
+++ b/async_processor_test.go
@@ -1,0 +1,24 @@
+package gortsplib
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsyncProcessorStopAfterError(t *testing.T) {
+	p := &asyncProcessor{bufferSize: 8}
+	p.initialize()
+
+	p.push(func() error {
+		return fmt.Errorf("ok")
+	})
+
+	p.start()
+
+	<-p.stopped
+	require.EqualError(t, p.stopError, "ok")
+
+	p.stop()
+}

--- a/client.go
+++ b/client.go
@@ -559,9 +559,9 @@ func (c *Client) runInner() error {
 			return nil
 		}()
 
-		chWriterError := func() chan error {
-			if c.writer != nil {
-				return c.writer.chError
+		chWriterError := func() chan struct{} {
+			if c.writer != nil && c.writer.running {
+				return c.writer.stopped
 			}
 			return nil
 		}()
@@ -637,8 +637,8 @@ func (c *Client) runInner() error {
 			}
 			c.keepaliveTimer = time.NewTimer(c.keepalivePeriod)
 
-		case err := <-chWriterError:
-			return err
+		case <-chWriterError:
+			return c.writer.stopError
 
 		case err := <-chReaderError:
 			c.reader = nil

--- a/client.go
+++ b/client.go
@@ -911,8 +911,6 @@ func (c *Client) stopTransportRoutines() {
 	}
 
 	c.timeDecoder = nil
-
-	c.writer = nil
 }
 
 func (c *Client) connOpen() error {

--- a/client_play_test.go
+++ b/client_play_test.go
@@ -1961,8 +1961,8 @@ func TestClientPlayPause(t *testing.T) {
 				})
 				require.NoError(t, err2)
 
-				req, err = conn.ReadRequest()
-				require.NoError(t, err)
+				req, err2 = conn.ReadRequest()
+				require.NoError(t, err2)
 				require.Equal(t, base.Play, req.Method)
 
 				err2 = conn.WriteResponse(&base.Response{


### PR DESCRIPTION
In https://github.com/bluenviron/gortsplib/pull/655 the change was made in `client.go` to set `writer` to `nil`, before completing the 'closing' of the client. This makes that if someone calls `WritePacketRTPWithNTP` after `writer = nil` but before `c.done` is closed, there is a panic. As described in https://github.com/bluenviron/gortsplib/issues/678. 

I don't fully understand why `c.writer = nil` is needed in the first place. It seems that before https://github.com/bluenviron/gortsplib/pull/655 `c.writer` is never set to `nil`. And after testing the situation of the panic, this resolved it. If someone has a better solution I'm very eager to learn!