### PR TITLE
Prevent sending TCP packets to a closed connection.

### DIFF
--- a/server_session.go
+++ b/server_session.go
@@ -1475,6 +1475,11 @@ func (ss *ServerSession) writePacketRTP(medi *description.Media, payloadType uin
 	}
 
 	ok := ss.writer.push(func() error {
+		ss.writerMutex.RLock()
+		defer ss.writerMutex.RUnlock()
+		if ss.writer == nil {
+			return nil
+		}
 		return sf.writePacketRTPInQueue(byts)
 	})
 	if !ok {


### PR DESCRIPTION
Fixes #689

This pull request includes an important change to the `writePacketRTP` function in the `server_session.go` file to ensure thread safety when accessing the `writer` object.

Thread safety improvements:

Added a read lock (`RLock`) and corresponding unlock (`RUnlock`) around the `writer` access in the `writePacketRTP` function to prevent concurrent access issues. Also added a nil check for `writer` to handle cases where it might be nil.

Bug was caused by setting `tcpConn` to `nil` on RTSP pause. The async writer would keep pulling in packets and sending them to `tcpConn` even after the connection has been marked `nil`.