### PR TITLE
Make mpeg4 clock rate configurable

### DIFF
--- a/pkg/format/mpeg4_video.go
+++ b/pkg/format/mpeg4_video.go
@@ -28,6 +28,11 @@ func (f *MPEG4Video) unmarshal(ctx *unmarshalContext) error {
 	f.PayloadTyp = ctx.payloadType
 	f.ProfileLevelID = 1 // default value imposed by specification
 
+	var err error
+	if f.SampleRate, err = strconv.Atoi(ctx.clock); err != nil {
+		return fmt.Errorf("could not parse clock rate: %v", err)
+	}
+
 	for key, val := range ctx.fmtp {
 		switch key {
 		case "profile-level-id":

--- a/pkg/format/mpeg4_video.go
+++ b/pkg/format/mpeg4_video.go
@@ -17,6 +17,7 @@ import (
 // Specification: https://datatracker.ietf.org/doc/html/rfc6416#section-7.1
 type MPEG4Video struct {
 	PayloadTyp     uint8
+	SampleRate     int
 	ProfileLevelID int
 	Config         []byte
 
@@ -61,7 +62,7 @@ func (f *MPEG4Video) Codec() string {
 
 // ClockRate implements Format.
 func (f *MPEG4Video) ClockRate() int {
-	return 90000
+	return f.SampleRate
 }
 
 // PayloadType implements Format.
@@ -71,7 +72,7 @@ func (f *MPEG4Video) PayloadType() uint8 {
 
 // RTPMap implements Format.
 func (f *MPEG4Video) RTPMap() string {
-	return "MP4V-ES/90000"
+	return "MP4V-ES/" + strconv.FormatInt(int64(f.SampleRate), 10)
 }
 
 // FMTP implements Format.


### PR DESCRIPTION
### What

	1.	Added SampleRate Field: A new field SampleRate of type int has been added to the MPEG4Video struct.
	2.	Updated ClockRate Method: The ClockRate method now returns the value of f.SampleRate instead of a hardcoded value of 90000.
	3.	Updated RTPMap Method: The RTPMap method has been modified to return a string that includes the SampleRate, formatted as "MP4V-ES/<SampleRate>".

### Why
These changes enhance the flexibility and accuracy of the MPEG4Video implementation by allowing the SampleRate to be dynamically set and retrieved. This is crucial for older cameras that support lower clock rates e.g. 30000.