### PR TITLE
fix URL method to correctly handle query strings

### DIFF
--- a/pkg/base/url.go
+++ b/pkg/base/url.go
@@ -105,3 +105,8 @@ func (u *URL) Hostname() string {
 func (u *URL) Port() string {
 	return (*url.URL)(u).Port()
 }
+
+// JoinPath joins a path to the URL.
+func (u *URL) JoinPath(elem ...string) *URL {
+	return (*URL)((*url.URL)(u).JoinPath(elem...))
+}

--- a/pkg/description/media.go
+++ b/pkg/description/media.go
@@ -193,17 +193,12 @@ func (m Media) URL(contentBase *base.URL) (*base.URL, error) {
 		return ur, nil
 	}
 
-	// control attribute contains a relative control attribute
-	// insert the control attribute at the end of the URL
-	// if there's a query, insert it after the query
-	// otherwise insert it after the path
-	strURL := contentBase.String()
-	if m.Control[0] != '?' && m.Control[0] != '/' && !strings.HasSuffix(strURL, "/") {
-		strURL += "/"
+	if m.Control[0] == '?' {
+		contentBase.RawQuery += "&" + m.Control[1:]
+		return contentBase, nil
 	}
 
-	ur, _ := base.ParseURL(strURL + m.Control)
-	return ur, nil
+	return contentBase.JoinPath(m.Control), nil
 }
 
 // FindFormat finds a certain format among all the formats in the media.


### PR DESCRIPTION
 - added JoinPath method in *base.URL
 - modified URL method in *description.Media to handle query strings

the original code handles that `a=control:?querystring` as query string. I wonder that this use case is standard or not, but I implemented it in the same way.

fixes #705 