### PR TITLE
Enable multiple RTSP clients to use the same UDP ports

### DIFF
--- a/client.go
+++ b/client.go
@@ -253,6 +253,14 @@ type Client struct {
 	// This can be a security issue.
 	// It defaults to false.
 	AnyPortEnable bool
+	// Use fixed UDP port for RTP on client side.
+	// If zero, random ports will be used.
+	// It defaults to 0.
+	ClientRTPPort int
+	// Use fixed UDP port for RTCP on client side.
+	// If zero, random ports will be used.
+	// It defaults to 0.
+	ClientRTCPPort int
 	// transport protocol (UDP, Multicast or TCP).
 	// If nil, it is chosen automatically (first UDP, then, if it fails, TCP).
 	// It defaults to nil.

--- a/client_media.go
+++ b/client_media.go
@@ -103,11 +103,21 @@ func (cm *clientMedia) start() {
 		cm.writePacketRTCPInQueue = cm.writePacketRTCPInQueueUDP
 
 		if cm.c.state == clientStateRecord || cm.media.IsBackChannel {
-			cm.udpRTPListener.readFunc = cm.readPacketRTPUDPRecord
-			cm.udpRTCPListener.readFunc = cm.readPacketRTCPUDPRecord
+			if cm.c.ClientRTPPort != 0 && cm.c.ClientRTCPPort != 0 {
+				cm.udpRTPListener.addServer(cm.udpRTPListener.readIP, cm.udpRTPListener.readPort, cm.readPacketRTPUDPRecord)
+				cm.udpRTCPListener.addServer(cm.udpRTCPListener.readIP, cm.udpRTCPListener.readPort, cm.readPacketRTCPUDPRecord)
+			} else {
+				cm.udpRTPListener.readFunc = cm.readPacketRTPUDPRecord
+				cm.udpRTCPListener.readFunc = cm.readPacketRTCPUDPRecord
+			}
 		} else {
-			cm.udpRTPListener.readFunc = cm.readPacketRTPUDPPlay
-			cm.udpRTCPListener.readFunc = cm.readPacketRTCPUDPPlay
+			if cm.c.ClientRTPPort != 0 && cm.c.ClientRTCPPort != 0 {
+				cm.udpRTPListener.addServer(cm.udpRTPListener.readIP, cm.udpRTPListener.readPort, cm.readPacketRTPUDPPlay)
+				cm.udpRTCPListener.addServer(cm.udpRTCPListener.readIP, cm.udpRTCPListener.readPort, cm.readPacketRTCPUDPPlay)
+			} else {
+				cm.udpRTPListener.readFunc = cm.readPacketRTPUDPPlay
+				cm.udpRTCPListener.readFunc = cm.readPacketRTCPUDPPlay
+			}
 		}
 	} else {
 		cm.writePacketRTCPInQueue = cm.writePacketRTCPInQueueTCP
@@ -137,6 +147,11 @@ func (cm *clientMedia) start() {
 
 func (cm *clientMedia) stop() {
 	if cm.udpRTPListener != nil {
+		if cm.c.ClientRTPPort != 0 && cm.c.ClientRTCPPort != 0 {
+			cm.udpRTPListener.removeServer(cm.udpRTPListener.readIP, cm.udpRTPListener.readPort)
+			cm.udpRTCPListener.removeServer(cm.udpRTCPListener.readIP, cm.udpRTCPListener.readPort)
+		}
+
 		cm.udpRTPListener.stop()
 		cm.udpRTCPListener.stop()
 	}


### PR DESCRIPTION
This PR enables multiple RTSP clients to use the same predefined UDP ports.

This allows users to expose a single pair of UDP ports for RTSP streaming with a UDP transport.