### PR TITLE
Fix incorrect function call

### DIFF
--- a/examples/server-h264-to-disk/mpegts_muxer.go
+++ b/examples/server-h264-to-disk/mpegts_muxer.go
@@ -101,5 +101,5 @@ func (e *mpegtsMuxer) writeH264(au [][]byte, pts int64) error {
 	}
 
 	// encode into MPEG-TS
-	return e.w.WriteH265(e.track, pts, dts, au)
+	return e.w.WriteH264(e.track, pts, dts, au)
 }


### PR DESCRIPTION
This PR fixes an incorrect function call in the example code located in examples/server-h264-to-disk/mpegts_muxer.go.

The issue was caused by the writeH264 function incorrectly calling WriteH265 instead of the correct WriteH264. This caused the example to behave incorrectly when handling H.264 data.