### PR TITLE
prevent decoders from returning empty NALUs (bluenviron/mediamtx#4346)

### DIFF
--- a/pkg/format/rtpav1/decoder.go
+++ b/pkg/format/rtpav1/decoder.go
@@ -60,6 +60,12 @@ func (d *Decoder) decodeOBUs(pkt *rtp.Packet) ([][]byte, error) {
 		return nil, fmt.Errorf("invalid header: %w", err)
 	}
 
+	for _, obu := range av1header.OBUElements {
+		if len(obu) == 0 {
+			return nil, fmt.Errorf("invalid OBU size")
+		}
+	}
+
 	if av1header.Z {
 		if d.fragmentsSize == 0 {
 			if !d.firstPacketReceived {

--- a/pkg/format/rtpav1/testdata/fuzz/FuzzDecoder/18413e36c51d1ebe
+++ b/pkg/format/rtpav1/testdata/fuzz/FuzzDecoder/18413e36c51d1ebe
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("0\x00")
+bool(true)
+[]byte("0")
+bool(true)

--- a/pkg/format/rtpav1/testdata/fuzz/FuzzDecoder/1ed61654a1dada4b
+++ b/pkg/format/rtpav1/testdata/fuzz/FuzzDecoder/1ed61654a1dada4b
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("0")
+bool(false)
+[]byte("0")
+bool(false)

--- a/pkg/format/rtpav1/testdata/fuzz/FuzzDecoder/1fd6e8e69fb31947
+++ b/pkg/format/rtpav1/testdata/fuzz/FuzzDecoder/1fd6e8e69fb31947
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("\x180")
+bool(false)
+[]byte("\xd00")
+bool(false)

--- a/pkg/format/rtpav1/testdata/fuzz/FuzzDecoder/cc0fa679ceee585f
+++ b/pkg/format/rtpav1/testdata/fuzz/FuzzDecoder/cc0fa679ceee585f
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("\xd00")
+bool(false)
+[]byte("0")
+bool(false)

--- a/pkg/format/rtph264/decoder.go
+++ b/pkg/format/rtph264/decoder.go
@@ -157,9 +157,13 @@ func (d *Decoder) decodeNALUs(pkt *rtp.Packet) ([][]byte, error) {
 			size := uint16(payload[0])<<8 | uint16(payload[1])
 			payload = payload[2:]
 
-			// discard padding
-			if size == 0 && isAllZero(payload) {
-				break
+			if size == 0 {
+				// discard padding
+				if isAllZero(payload) {
+					break
+				}
+
+				return nil, fmt.Errorf("invalid STAP-A packet (invalid size)")
 			}
 
 			if int(size) > len(payload) {

--- a/pkg/format/rtph264/decoder_test.go
+++ b/pkg/format/rtph264/decoder_test.go
@@ -275,32 +275,39 @@ func TestDecodeErrorMissingPacket(t *testing.T) {
 }
 
 func FuzzDecoder(f *testing.F) {
-	f.Fuzz(func(_ *testing.T, a []byte, b []byte) {
+	f.Fuzz(func(t *testing.T, a []byte, am bool, b []byte, bm bool) {
 		d := &Decoder{}
-		d.Init() //nolint:errcheck
+		err := d.Init()
+		require.NoError(t, err)
 
-		d.Decode(&rtp.Packet{ //nolint:errcheck
+		au, err := d.Decode(&rtp.Packet{
 			Header: rtp.Header{
-				Version:        2,
-				Marker:         false,
-				PayloadType:    96,
+				Marker:         am,
 				SequenceNumber: 17645,
-				Timestamp:      2289527317,
-				SSRC:           0x9dbb7812,
 			},
 			Payload: a,
 		})
 
-		d.Decode(&rtp.Packet{ //nolint:errcheck
-			Header: rtp.Header{
-				Version:        2,
-				Marker:         false,
-				PayloadType:    96,
-				SequenceNumber: 17645,
-				Timestamp:      2289527317,
-				SSRC:           0x9dbb7812,
-			},
-			Payload: b,
-		})
+		if errors.Is(err, ErrMorePacketsNeeded) {
+			au, err = d.Decode(&rtp.Packet{
+				Header: rtp.Header{
+					Marker:         bm,
+					SequenceNumber: 17646,
+				},
+				Payload: b,
+			})
+		}
+
+		if err == nil {
+			if len(au) == 0 {
+				t.Errorf("should not happen")
+			}
+
+			for _, nalu := range au {
+				if len(nalu) == 0 {
+					t.Errorf("should not happen")
+				}
+			}
+		}
 	})
 }

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/15fcae9a402a0f11
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/15fcae9a402a0f11
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("8")
+bool(false)
+[]byte("0")
+bool(true)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/3707105d86e9ef3c
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/3707105d86e9ef3c
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("0")
+bool(false)
+[]byte("\x00\x00\x00\x01")
+bool(false)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/3a1859786e5a6231
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/3a1859786e5a6231
@@ -1,3 +1,5 @@
 go test fuzz v1
 []byte("800")
+bool(false)
 []byte("0")
+bool(true)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/3b0600afabf53c93
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/3b0600afabf53c93
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("8\x00\x000")

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/5ad0b5168b26857a
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/5ad0b5168b26857a
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("")
+bool(false)
+[]byte("0")
+bool(true)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/5b424cab7437770c
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/5b424cab7437770c
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("0")
+bool(false)
+[]byte("8\x00\x00\x00\x010")
+bool(true)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/60892a24d67609fc
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/60892a24d67609fc
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("8")
-[]byte("")

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/6a8b2220ade9c21d
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/6a8b2220ade9c21d
@@ -1,5 +1,5 @@
 go test fuzz v1
-[]byte("\x190")
+[]byte("\xdc")
 bool(false)
-[]byte("\xd00")
+[]byte("0")
 bool(false)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/84ed65595ad05a58
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/84ed65595ad05a58
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("")

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/9b4d0ab6bd98d3a9
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/9b4d0ab6bd98d3a9
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("80")

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/9de59c1cbda7c1b0
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/9de59c1cbda7c1b0
@@ -1,5 +1,5 @@
 go test fuzz v1
-[]byte("0\x00")
-bool(true)
 []byte("0")
 bool(false)
+[]byte("0")
+bool(true)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/a900b5d3c2c2772a
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/a900b5d3c2c2772a
@@ -1,5 +1,5 @@
 go test fuzz v1
-[]byte("\xd00")
+[]byte("\xdc0")
 bool(false)
-[]byte("")
+[]byte("0")
 bool(false)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/b8149c97ccea034d
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/b8149c97ccea034d
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("8\x00\x00")
+bool(false)
+[]byte("0")
+bool(true)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/ecf7d0b7f06fcc4a
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/ecf7d0b7f06fcc4a
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("<")

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/edbcdbb8d9f1bdac
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/edbcdbb8d9f1bdac
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("\\0")

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/ef42b0cea98081da
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/ef42b0cea98081da
@@ -1,5 +1,5 @@
 go test fuzz v1
-[]byte("")
+[]byte("0")
 bool(false)
-[]byte("")
+[]byte("9000")
 bool(false)

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/ef62dc47a38f1a39
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/ef62dc47a38f1a39
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("9")

--- a/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/fc2b1d7ceef39c14
+++ b/pkg/format/rtph264/testdata/fuzz/FuzzDecoder/fc2b1d7ceef39c14
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("0")
+bool(false)
+[]byte("|0")
+bool(true)

--- a/pkg/format/rtph265/decoder.go
+++ b/pkg/format/rtph265/decoder.go
@@ -81,7 +81,7 @@ func (d *Decoder) decodeNALUs(pkt *rtp.Packet) ([][]byte, error) {
 			size := uint16(payload[0])<<8 | uint16(payload[1])
 			payload = payload[2:]
 
-			if int(size) > len(payload) {
+			if size == 0 || int(size) > len(payload) {
 				return nil, fmt.Errorf("invalid aggregation unit (invalid size)")
 			}
 
@@ -91,10 +91,6 @@ func (d *Decoder) decodeNALUs(pkt *rtp.Packet) ([][]byte, error) {
 			if len(payload) == 0 {
 				break
 			}
-		}
-
-		if nalus == nil {
-			return nil, fmt.Errorf("aggregation unit doesn't contain any NALU")
 		}
 
 		d.firstPacketReceived = true

--- a/pkg/format/rtph265/decoder_test.go
+++ b/pkg/format/rtph265/decoder_test.go
@@ -92,32 +92,39 @@ func TestDecodeErrorMissingPacket(t *testing.T) {
 }
 
 func FuzzDecoder(f *testing.F) {
-	f.Fuzz(func(_ *testing.T, a []byte, b []byte) {
+	f.Fuzz(func(t *testing.T, a []byte, am bool, b []byte, bm bool) {
 		d := &Decoder{}
-		d.Init() //nolint:errcheck
+		err := d.Init()
+		require.NoError(t, err)
 
-		d.Decode(&rtp.Packet{ //nolint:errcheck
+		au, err := d.Decode(&rtp.Packet{
 			Header: rtp.Header{
-				Version:        2,
-				Marker:         false,
-				PayloadType:    96,
+				Marker:         am,
 				SequenceNumber: 17645,
-				Timestamp:      2289527317,
-				SSRC:           0x9dbb7812,
 			},
 			Payload: a,
 		})
 
-		d.Decode(&rtp.Packet{ //nolint:errcheck
-			Header: rtp.Header{
-				Version:        2,
-				Marker:         false,
-				PayloadType:    96,
-				SequenceNumber: 17645,
-				Timestamp:      2289527317,
-				SSRC:           0x9dbb7812,
-			},
-			Payload: b,
-		})
+		if errors.Is(err, ErrMorePacketsNeeded) {
+			au, err = d.Decode(&rtp.Packet{
+				Header: rtp.Header{
+					Marker:         bm,
+					SequenceNumber: 17646,
+				},
+				Payload: b,
+			})
+		}
+
+		if err == nil {
+			if len(au) == 0 {
+				t.Errorf("should not happen")
+			}
+
+			for _, nalu := range au {
+				if len(nalu) == 0 {
+					t.Errorf("should not happen")
+				}
+			}
+		}
 	})
 }

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/14cfad5b98d00ac8
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/14cfad5b98d00ac8
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("b0")
+bool(false)
+[]byte("0")
+bool(false)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/17e52f9247ad1b2a
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/17e52f9247ad1b2a
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("a0")
+bool(false)
+[]byte("0")
+bool(true)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/18fae30536d2c3ba
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/18fae30536d2c3ba
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("d0")
+bool(false)
+[]byte("0")
+bool(true)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/25f2b139d5d03b01
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/25f2b139d5d03b01
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("00")
-[]byte("b00")

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/2d69a60004f3edfd
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/2d69a60004f3edfd
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("b0")

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/5cedd25e23c9f9aa
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/5cedd25e23c9f9aa
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("a00")

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/69e1cb9d2d26f61f
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/69e1cb9d2d26f61f
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("00")
+bool(false)
+[]byte("b0\xc1")
+bool(true)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/717a02ebf21c41db
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/717a02ebf21c41db
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("\xe50")

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/728cd1cec4fb0ff2
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/728cd1cec4fb0ff2
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("b00")
+bool(false)
+[]byte("0")
+bool(false)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/84ed65595ad05a58
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/84ed65595ad05a58
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("0")
-[]byte("")

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/95e634df087d6476
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/95e634df087d6476
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("a0")
-[]byte("")

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/9de59c1cbda7c1b0
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/9de59c1cbda7c1b0
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("0")
+bool(false)
+[]byte("0")
+bool(true)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/a7fab38f1f1629f8
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/a7fab38f1f1629f8
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("b0\xd2")
-[]byte("0")

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/ab70f5936ef75670
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/ab70f5936ef75670
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("00")
+bool(false)
+[]byte("00")
+bool(true)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/af9c0e4e34bfcb3e
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/af9c0e4e34bfcb3e
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("a0\x00\t000000000")
+bool(false)
+[]byte("b00")
+bool(true)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/ba1f81d88619462f
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/ba1f81d88619462f
@@ -1,0 +1,5 @@
+go test fuzz v1
+[]byte("00")
+bool(false)
+[]byte("a0\x00\x00")
+bool(true)

--- a/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/e807a721f4e89fcb
+++ b/pkg/format/rtph265/testdata/fuzz/FuzzDecoder/e807a721f4e89fcb
@@ -1,3 +1,0 @@
-go test fuzz v1
-[]byte("a000")
-[]byte("0")


### PR DESCRIPTION
Fixes bluenviron/mediamtx#4346