### PR TITLE
Allow setting response body in OnDescribe

### DIFF
--- a/server_conn.go
+++ b/server_conn.go
@@ -328,8 +328,8 @@ func (sc *ServerConn) handleRequestInner(req *base.Request) (*base.Response, err
 			})
 
 			if res.StatusCode == base.StatusOK {
-				if stream == nil {
-					panic("stream cannot be nil when StatusCode is StatusOK")
+				if stream == nil && len(res.Body) == 0 {
+					panic("stream should be not nil or response body should be nonempty when StatusCode is StatusOK")
 				}
 
 				if res.Header == nil {
@@ -338,6 +338,10 @@ func (sc *ServerConn) handleRequestInner(req *base.Request) (*base.Response, err
 
 				res.Header["Content-Base"] = base.HeaderValue{req.URL.String() + "/"}
 				res.Header["Content-Type"] = base.HeaderValue{"application/sdp"}
+
+				if stream == nil {
+					return res, err
+				}
 
 				// VLC uses multicast if the SDP contains a multicast address.
 				// therefore, we introduce a special query (vlcmulticast) that allows


### PR DESCRIPTION
Since commit 8c6495c33b3194f1bf34f3f8a87f51907e567915, the server can no longer directly specify the response body to DESCRIBE requests. This is a breaking change and is a limitation for users who manually handle their SDPs. This commit allows setting the body explicitly and takes it into account if the `ServerStream` part of the `OnDecsribe` return value is nil. If neither the stream, nor the body are set, the application panics.

@aler9 if you approve this change, I can amend the tests.