### PR TITLE
unexport multicast.MultiConn, multicast.SingleConn

### DIFF
--- a/pkg/multicast/multi_conn.go
+++ b/pkg/multicast/multi_conn.go
@@ -11,9 +11,9 @@ import (
 	"golang.org/x/net/ipv4"
 )
 
-// MultiConn is a multicast connection
+// multiConn is a multicast connection
 // that works in parallel on all interfaces.
-type MultiConn struct {
+type multiConn struct {
 	addr         *net.UDPAddr
 	readConn     *net.UDPConn
 	readConnIP   *ipv4.PacketConn
@@ -21,7 +21,7 @@ type MultiConn struct {
 	writeConnIPs []*ipv4.PacketConn
 }
 
-// NewMultiConn allocates a MultiConn.
+// NewMultiConn allocates a multi-interface multicast connection.
 func NewMultiConn(
 	address string,
 	readOnly bool,
@@ -110,7 +110,7 @@ func NewMultiConn(
 		}
 	}
 
-	return &MultiConn{
+	return &multiConn{
 		addr:         addr,
 		readConn:     readConn,
 		readConnIP:   readConnIP,
@@ -120,7 +120,7 @@ func NewMultiConn(
 }
 
 // Close implements Conn.
-func (c *MultiConn) Close() error {
+func (c *multiConn) Close() error {
 	for _, c := range c.writeConns {
 		c.Close() //nolint:errcheck
 	}
@@ -129,27 +129,27 @@ func (c *MultiConn) Close() error {
 }
 
 // SetReadBuffer implements Conn.
-func (c *MultiConn) SetReadBuffer(bytes int) error {
+func (c *multiConn) SetReadBuffer(bytes int) error {
 	return c.readConn.SetReadBuffer(bytes)
 }
 
 // LocalAddr implements Conn.
-func (c *MultiConn) LocalAddr() net.Addr {
+func (c *multiConn) LocalAddr() net.Addr {
 	return c.readConn.LocalAddr()
 }
 
 // SetDeadline implements Conn.
-func (c *MultiConn) SetDeadline(_ time.Time) error {
+func (c *multiConn) SetDeadline(_ time.Time) error {
 	panic("unimplemented")
 }
 
 // SetReadDeadline implements Conn.
-func (c *MultiConn) SetReadDeadline(t time.Time) error {
+func (c *multiConn) SetReadDeadline(t time.Time) error {
 	return c.readConn.SetReadDeadline(t)
 }
 
 // SetWriteDeadline implements Conn.
-func (c *MultiConn) SetWriteDeadline(t time.Time) error {
+func (c *multiConn) SetWriteDeadline(t time.Time) error {
 	var err error
 	for _, c := range c.writeConns {
 		err2 := c.SetWriteDeadline(t)
@@ -161,7 +161,7 @@ func (c *MultiConn) SetWriteDeadline(t time.Time) error {
 }
 
 // WriteTo implements Conn.
-func (c *MultiConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+func (c *multiConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 	var n int
 	var err error
 	for _, c := range c.writeConns {
@@ -175,6 +175,6 @@ func (c *MultiConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 }
 
 // ReadFrom implements Conn.
-func (c *MultiConn) ReadFrom(b []byte) (int, net.Addr, error) {
+func (c *multiConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	return c.readConn.ReadFrom(b)
 }

--- a/pkg/multicast/single_conn.go
+++ b/pkg/multicast/single_conn.go
@@ -15,15 +15,15 @@ const (
 	multicastTTL = 16
 )
 
-// SingleConn is a multicast connection
+// singleConn is a multicast connection
 // that works on a single interface.
-type SingleConn struct {
+type singleConn struct {
 	addr   *net.UDPAddr
 	conn   *net.UDPConn
 	connIP *ipv4.PacketConn
 }
 
-// NewSingleConn allocates a SingleConn.
+// NewSingleConn allocates a single-interface multicast connection.
 func NewSingleConn(
 	intf *net.Interface,
 	address string,
@@ -60,7 +60,7 @@ func NewSingleConn(
 		return nil, err
 	}
 
-	return &SingleConn{
+	return &singleConn{
 		addr:   addr,
 		conn:   conn,
 		connIP: connIP,
@@ -68,41 +68,41 @@ func NewSingleConn(
 }
 
 // Close implements Conn.
-func (c *SingleConn) Close() error {
+func (c *singleConn) Close() error {
 	return c.conn.Close()
 }
 
 // SetReadBuffer implements Conn.
-func (c *SingleConn) SetReadBuffer(bytes int) error {
+func (c *singleConn) SetReadBuffer(bytes int) error {
 	return c.conn.SetReadBuffer(bytes)
 }
 
 // LocalAddr implements Conn.
-func (c *SingleConn) LocalAddr() net.Addr {
+func (c *singleConn) LocalAddr() net.Addr {
 	return c.conn.LocalAddr()
 }
 
 // SetDeadline implements Conn.
-func (c *SingleConn) SetDeadline(_ time.Time) error {
+func (c *singleConn) SetDeadline(_ time.Time) error {
 	panic("unimplemented")
 }
 
 // SetReadDeadline implements Conn.
-func (c *SingleConn) SetReadDeadline(t time.Time) error {
+func (c *singleConn) SetReadDeadline(t time.Time) error {
 	return c.conn.SetReadDeadline(t)
 }
 
 // SetWriteDeadline implements Conn.
-func (c *SingleConn) SetWriteDeadline(t time.Time) error {
+func (c *singleConn) SetWriteDeadline(t time.Time) error {
 	return c.conn.SetWriteDeadline(t)
 }
 
 // WriteTo implements Conn.
-func (c *SingleConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+func (c *singleConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 	return c.conn.WriteTo(b, addr)
 }
 
 // ReadFrom implements Conn.
-func (c *SingleConn) ReadFrom(b []byte) (int, net.Addr, error) {
+func (c *singleConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	return c.conn.ReadFrom(b)
 }

--- a/pkg/multicast/single_conn_lin.go
+++ b/pkg/multicast/single_conn_lin.go
@@ -41,15 +41,15 @@ func setIPMreqInterface(mreq *syscall.IPMreq, ifi *net.Interface) error {
 	return fmt.Errorf("no such interface")
 }
 
-// SingleConn is a multicast connection
+// singleConn is a multicast connection
 // that works on a single interface.
-type SingleConn struct {
+type singleConn struct {
 	addr *net.UDPAddr
 	file *os.File
 	conn net.PacketConn
 }
 
-// NewSingleConn allocates a SingleConn.
+// NewSingleConn allocates a singleConn.
 func NewSingleConn(
 	intf *net.Interface,
 	address string,
@@ -122,7 +122,7 @@ func NewSingleConn(
 		return nil, err
 	}
 
-	return &SingleConn{
+	return &singleConn{
 		addr: addr,
 		file: file,
 		conn: conn,
@@ -130,43 +130,43 @@ func NewSingleConn(
 }
 
 // Close implements Conn.
-func (c *SingleConn) Close() error {
+func (c *singleConn) Close() error {
 	c.conn.Close()
 	c.file.Close()
 	return nil
 }
 
 // SetReadBuffer implements Conn.
-func (c *SingleConn) SetReadBuffer(bytes int) error {
+func (c *singleConn) SetReadBuffer(bytes int) error {
 	return syscall.SetsockoptInt(int(c.file.Fd()), syscall.SOL_SOCKET, syscall.SO_RCVBUF, bytes)
 }
 
 // LocalAddr implements Conn.
-func (c *SingleConn) LocalAddr() net.Addr {
+func (c *singleConn) LocalAddr() net.Addr {
 	return c.conn.LocalAddr()
 }
 
 // SetDeadline implements Conn.
-func (c *SingleConn) SetDeadline(_ time.Time) error {
+func (c *singleConn) SetDeadline(_ time.Time) error {
 	panic("unimplemented")
 }
 
 // SetReadDeadline implements Conn.
-func (c *SingleConn) SetReadDeadline(t time.Time) error {
+func (c *singleConn) SetReadDeadline(t time.Time) error {
 	return c.conn.SetReadDeadline(t)
 }
 
 // SetWriteDeadline implements Conn.
-func (c *SingleConn) SetWriteDeadline(t time.Time) error {
+func (c *singleConn) SetWriteDeadline(t time.Time) error {
 	return c.conn.SetWriteDeadline(t)
 }
 
 // WriteTo implements Conn.
-func (c *SingleConn) WriteTo(b []byte, addr net.Addr) (int, error) {
+func (c *singleConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 	return c.conn.WriteTo(b, addr)
 }
 
 // ReadFrom implements Conn.
-func (c *SingleConn) ReadFrom(b []byte) (int, net.Addr, error) {
+func (c *singleConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	return c.conn.ReadFrom(b)
 }


### PR DESCRIPTION
they are already exposed through multicast.Conn.