### PR TITLE
fix crash when reading tracks with zero clock rate

### DIFF
--- a/client_media.go
+++ b/client_media.go
@@ -146,7 +146,7 @@ func (cm *clientMedia) stop() {
 	}
 }
 
-func (cm *clientMedia) findFormatWithSSRC(ssrc uint32) *clientFormat {
+func (cm *clientMedia) findFormatBySSRC(ssrc uint32) *clientFormat {
 	for _, format := range cm.formats {
 		stats := format.rtcpReceiver.Stats()
 		if stats != nil && stats.RemoteSSRC == ssrc {
@@ -226,7 +226,7 @@ func (cm *clientMedia) readPacketRTCPTCPPlay(payload []byte) bool {
 
 	for _, pkt := range packets {
 		if sr, ok := pkt.(*rtcp.SenderReport); ok {
-			format := cm.findFormatWithSSRC(sr.SSRC)
+			format := cm.findFormatBySSRC(sr.SSRC)
 			if format != nil {
 				format.rtcpReceiver.ProcessSenderReport(sr, now)
 			}
@@ -311,7 +311,7 @@ func (cm *clientMedia) readPacketRTCPUDPPlay(payload []byte) bool {
 
 	for _, pkt := range packets {
 		if sr, ok := pkt.(*rtcp.SenderReport); ok {
-			format := cm.findFormatWithSSRC(sr.SSRC)
+			format := cm.findFormatBySSRC(sr.SSRC)
 			if format != nil {
 				format.rtcpReceiver.ProcessSenderReport(sr, now)
 			}

--- a/pkg/rtcpsender/rtcpsender.go
+++ b/pkg/rtcpsender/rtcpsender.go
@@ -71,6 +71,12 @@ func (rs *RTCPSender) Initialize() {
 	go rs.run()
 }
 
+// Close closes the RTCPSender.
+func (rs *RTCPSender) Close() {
+	close(rs.terminate)
+	<-rs.done
+}
+
 func (rs *RTCPSender) run() {
 	defer close(rs.done)
 
@@ -95,7 +101,7 @@ func (rs *RTCPSender) report() rtcp.Packet {
 	rs.mutex.Lock()
 	defer rs.mutex.Unlock()
 
-	if !rs.firstRTPPacketSent {
+	if !rs.firstRTPPacketSent || rs.ClockRate == 0 {
 		return nil
 	}
 
@@ -110,12 +116,6 @@ func (rs *RTCPSender) report() rtcp.Packet {
 		PacketCount: rs.packetCount,
 		OctetCount:  rs.octetCount,
 	}
-}
-
-// Close closes the RTCPSender.
-func (rs *RTCPSender) Close() {
-	close(rs.terminate)
-	<-rs.done
 }
 
 // ProcessPacket extracts data from RTP packets.

--- a/server_session_media.go
+++ b/server_session_media.go
@@ -112,7 +112,7 @@ func (sm *serverSessionMedia) stop() {
 	}
 }
 
-func (sm *serverSessionMedia) findFormatWithSSRC(ssrc uint32) *serverSessionFormat {
+func (sm *serverSessionMedia) findFormatBySSRC(ssrc uint32) *serverSessionFormat {
 	for _, format := range sm.formats {
 		stats := format.rtcpReceiver.Stats()
 		if stats != nil && stats.RemoteSSRC == ssrc {
@@ -223,7 +223,7 @@ func (sm *serverSessionMedia) readPacketRTCPUDPRecord(payload []byte) bool {
 
 	for _, pkt := range packets {
 		if sr, ok := pkt.(*rtcp.SenderReport); ok {
-			format := sm.findFormatWithSSRC(sr.SSRC)
+			format := sm.findFormatBySSRC(sr.SSRC)
 			if format != nil {
 				format.rtcpReceiver.ProcessSenderReport(sr, now)
 			}
@@ -303,7 +303,7 @@ func (sm *serverSessionMedia) readPacketRTCPTCPRecord(payload []byte) bool {
 
 	for _, pkt := range packets {
 		if sr, ok := pkt.(*rtcp.SenderReport); ok {
-			format := sm.findFormatWithSSRC(sr.SSRC)
+			format := sm.findFormatBySSRC(sr.SSRC)
 			if format != nil {
 				format.rtcpReceiver.ProcessSenderReport(sr, now)
 			}


### PR DESCRIPTION
(bluenviron/mediamtx#4476)

also prevents RTCP sender and RTCP reports from being emitted when track has clock rate set to zero.