### PR TITLE
client: fix reading sources without server ports (bluenviron/mediamtx#4253)

### DIFF
--- a/client_format.go
+++ b/client_format.go
@@ -67,7 +67,7 @@ func (cf *clientFormat) start() {
 			Period:    cf.cm.c.receiverReportPeriod,
 			TimeNow:   cf.cm.c.timeNow,
 			WritePacketRTCP: func(pkt rtcp.Packet) {
-				if cf.cm.udpRTPListener != nil {
+				if cf.cm.udpRTPListener != nil && cf.cm.udpRTCPListener.writeAddr != nil {
 					cf.cm.c.WritePacketRTCP(cf.cm.media, pkt) //nolint:errcheck
 				}
 			},


### PR DESCRIPTION
Fixes bluenviron/mediamtx#4253

RTCP packets were sent out to nil addresses, due to the lack of server ports, causing an error.