### PR TITLE
Allow to supply parent context to Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -331,6 +331,7 @@ type Client struct {
 	checkTimeoutPeriod   time.Duration
 
 	connURL              *base.URL
+	ParentCtx            context.Context
 	ctx                  context.Context
 	ctxCancel            func()
 	state                clientState
@@ -472,7 +473,14 @@ func (c *Client) Start(scheme string, host string) error {
 		c.checkTimeoutPeriod = 1 * time.Second
 	}
 
-	ctx, ctxCancel := context.WithCancel(context.Background())
+	var parentCtx context.Context
+	if c.ParentCtx == nil {
+		parentCtx = context.Background()
+	} else {
+		parentCtx = c.ParentCtx
+	}
+
+	ctx, ctxCancel := context.WithCancel(parentCtx)
 
 	c.connURL = &base.URL{
 		Scheme: scheme,


### PR DESCRIPTION
`Client` can be used in an environment already utilizing a `context.Context` (e.g. in order to handle signals / graceful shutdown). In such a scenario `Client` should be creating a child context, not a brand new one of its own.

The immediate problem that I faced was that the app wouldn't immediately drop attempting to connect to a RTSP server when interrupted with SIGINT/SIGTERM: it would hang until the `Client` condescends.