### PR TITLE
set SSRC of outgoing packets

### DIFF
--- a/client_play_test.go
+++ b/client_play_test.go
@@ -558,6 +558,48 @@ func TestClientPlay(t *testing.T) {
 			<-packetRecv
 
 			s := c.Stats()
+			require.Equal(t, &ClientStats{
+				Conn: StatsConn{
+					BytesReceived: s.Conn.BytesReceived,
+					BytesSent:     s.Conn.BytesSent,
+				},
+				Session: StatsSession{
+					BytesReceived:       s.Session.BytesReceived,
+					BytesSent:           s.Session.BytesSent,
+					RTPPacketsReceived:  s.Session.RTPPacketsReceived,
+					RTCPPacketsReceived: s.Session.RTCPPacketsReceived,
+					RTCPPacketsSent:     s.Session.RTCPPacketsSent,
+					Medias: map[*description.Media]StatsSessionMedia{
+						sd.Medias[0]: { //nolint:dupl
+							BytesReceived:       s.Session.Medias[sd.Medias[0]].BytesReceived,
+							BytesSent:           s.Session.Medias[sd.Medias[0]].BytesSent,
+							RTCPPacketsReceived: s.Session.Medias[sd.Medias[0]].RTCPPacketsReceived,
+							RTCPPacketsSent:     s.Session.Medias[sd.Medias[0]].RTCPPacketsSent,
+							Formats: map[format.Format]StatsSessionFormat{
+								sd.Medias[0].Formats[0]: {
+									RTPPacketsReceived: s.Session.Medias[sd.Medias[0]].Formats[sd.Medias[0].Formats[0]].RTPPacketsReceived,
+									LocalSSRC:          s.Session.Medias[sd.Medias[0]].Formats[sd.Medias[0].Formats[0]].LocalSSRC,
+									RemoteSSRC:         s.Session.Medias[sd.Medias[0]].Formats[sd.Medias[0].Formats[0]].RemoteSSRC,
+								},
+							},
+						},
+						sd.Medias[1]: { //nolint:dupl
+							BytesReceived:       s.Session.Medias[sd.Medias[1]].BytesReceived,
+							BytesSent:           s.Session.Medias[sd.Medias[1]].BytesSent,
+							RTCPPacketsReceived: s.Session.Medias[sd.Medias[1]].RTCPPacketsReceived,
+							RTCPPacketsSent:     s.Session.Medias[sd.Medias[1]].RTCPPacketsSent,
+							Formats: map[format.Format]StatsSessionFormat{
+								sd.Medias[1].Formats[0]: {
+									RTPPacketsReceived: s.Session.Medias[sd.Medias[1]].Formats[sd.Medias[1].Formats[0]].RTPPacketsReceived,
+									LocalSSRC:          s.Session.Medias[sd.Medias[1]].Formats[sd.Medias[1].Formats[0]].LocalSSRC,
+									RemoteSSRC:         s.Session.Medias[sd.Medias[1]].Formats[sd.Medias[1].Formats[0]].RemoteSSRC,
+								},
+							},
+						},
+					},
+				},
+			}, s)
+
 			require.Greater(t, s.Session.BytesSent, uint64(19))
 			require.Less(t, s.Session.BytesSent, uint64(41))
 			require.Greater(t, s.Session.BytesReceived, uint64(31))

--- a/pkg/rtcpreceiver/rtcpreceiver.go
+++ b/pkg/rtcpreceiver/rtcpreceiver.go
@@ -87,6 +87,8 @@ func New(
 
 // Initialize initializes RTCPReceiver.
 func (rr *RTCPReceiver) Initialize() error {
+	// Deprecated: passing a nil LocalSSRC will be deprecated from next version.
+	// Please use a fixed LocalSSRC.
 	if rr.LocalSSRC == nil {
 		v, err := randUint32()
 		if err != nil {

--- a/pkg/rtcpsender/rtcpsender.go
+++ b/pkg/rtcpsender/rtcpsender.go
@@ -163,7 +163,10 @@ func (rs *RTCPSender) LastPacketData() (uint16, uint32, time.Time, bool) {
 
 // Stats are statistics.
 type Stats struct {
-	LocalSSRC          uint32
+	// Deprecated: this is not a statistics anymore but a fixed parameter.
+	// it will be removed in next version.
+	LocalSSRC uint32
+
 	LastSequenceNumber uint16
 	LastRTP            uint32
 	LastNTP            time.Time

--- a/server_record_test.go
+++ b/server_record_test.go
@@ -606,6 +606,7 @@ func TestServerRecord(t *testing.T) {
 								ctx.Session.AnnouncedDescription().Medias[i],
 								ctx.Session.AnnouncedDescription().Medias[i].Formats[0],
 								func(pkt *rtp.Packet) {
+									pkt.SSRC = testRTPPacket.SSRC
 									require.Equal(t, &testRTPPacket, pkt)
 								})
 

--- a/server_test.go
+++ b/server_test.go
@@ -754,6 +754,7 @@ func TestServerSetupMultipleTransports(t *testing.T) {
 		Delivery:       deliveryPtr(headers.TransportDeliveryUnicast),
 		Protocol:       headers.TransportProtocolTCP,
 		InterleavedIDs: &[2]int{0, 1},
+		SSRC:           th.SSRC,
 	}, th)
 }
 


### PR DESCRIPTION
In client and server, each format now has a fixed, unique, known in
advance SSRC, that is applied to outgoing packets belonging to each
format.

This is needed to support SRTP/MIKEY, that require each format to have
a fixed, unique, and known in advance SSRC.

A secondary effect is that SETUP responses now always contain SSRCs of
each format, regardless of the fact that the first packet has been
produced or not (previously we needed at least one packet, from which
the SSRC was extracted).