### PR TITLE
server: improve log messages (NFC)

### DIFF
--- a/server.go
+++ b/server.go
@@ -217,7 +217,7 @@ func (s *Server) Start() error {
 		}
 
 		if (rtpPort % 2) != 0 {
-			return fmt.Errorf("RTP (%d) port must be even", rtpPort)
+			return fmt.Errorf("RTP port (%d) must be even", rtpPort)
 		}
 
 		if rtcpPort != (rtpPort + 1) {

--- a/server.go
+++ b/server.go
@@ -158,12 +158,12 @@ func (s *Server) Start() error {
 	if s.WriteQueueSize == 0 {
 		s.WriteQueueSize = 256
 	} else if (s.WriteQueueSize & (s.WriteQueueSize - 1)) != 0 {
-		return fmt.Errorf("WriteQueueSize must be a power of two")
+		return fmt.Errorf("WriteQueueSize (%d) must be a power of two", s.WriteQueueSize)
 	}
 	if s.MaxPacketSize == 0 {
 		s.MaxPacketSize = udpMaxPayloadSize
 	} else if s.MaxPacketSize > udpMaxPayloadSize {
-		return fmt.Errorf("MaxPacketSize must be less than %d", udpMaxPayloadSize)
+		return fmt.Errorf("MaxPacketSize (%d) must be less than %d", s.MaxPacketSize, udpMaxPayloadSize)
 	}
 	if len(s.AuthMethods) == 0 {
 		// disable VerifyMethodDigestSHA256 unless explicitly set
@@ -217,11 +217,11 @@ func (s *Server) Start() error {
 		}
 
 		if (rtpPort % 2) != 0 {
-			return fmt.Errorf("RTP port must be even")
+			return fmt.Errorf("RTP (%d) port must be even", rtpPort)
 		}
 
 		if rtcpPort != (rtpPort + 1) {
-			return fmt.Errorf("RTP and RTCP ports must be consecutive")
+			return fmt.Errorf("RTP (%d) and RTCP (%d) ports must be consecutive", rtpPort, rtcpPort)
 		}
 
 		s.udpRTPListener = &serverUDPListener{
@@ -268,7 +268,7 @@ func (s *Server) Start() error {
 			if s.udpRTCPListener != nil {
 				s.udpRTCPListener.close()
 			}
-			return fmt.Errorf("RTP port must be even")
+			return fmt.Errorf("RTP port (%d) must be even", s.MulticastRTPPort)
 		}
 
 		if s.MulticastRTCPPort != (s.MulticastRTPPort + 1) {
@@ -278,7 +278,7 @@ func (s *Server) Start() error {
 			if s.udpRTCPListener != nil {
 				s.udpRTCPListener.close()
 			}
-			return fmt.Errorf("RTP and RTCP ports must be consecutive")
+			return fmt.Errorf("Multicast RTP (%d) and RTCP (%d) ports must be consecutive", s.MulticastRTPPort, s.MulticastRTCPPort)
 		}
 
 		var err error

--- a/server.go
+++ b/server.go
@@ -278,7 +278,8 @@ func (s *Server) Start() error {
 			if s.udpRTCPListener != nil {
 				s.udpRTCPListener.close()
 			}
-			return fmt.Errorf("Multicast RTP (%d) and RTCP (%d) ports must be consecutive", s.MulticastRTPPort, s.MulticastRTCPPort)
+			return fmt.Errorf("multicast RTP (%d) and RTCP (%d) ports must be consecutive",
+				s.MulticastRTPPort, s.MulticastRTCPPort)
 		}
 
 		var err error


### PR DESCRIPTION
When mediamtx failed to start, It was not clear what port caused the error. Also, there are error messages with the same wording in multiple places, which makes debugging harder.

This PR adds dumping of actual port values in `server.go`.