### PR TITLE
client: use server interface as multicast interface (#762)

### DIFF
--- a/client_media.go
+++ b/client_media.go
@@ -101,17 +101,17 @@ func (cm *clientMedia) close() {
 }
 
 func (cm *clientMedia) createUDPListeners(
-	multicastEnable bool,
-	multicastSourceIP net.IP,
+	multicast bool,
+	multicastInterface *net.Interface,
 	rtpAddress string,
 	rtcpAddress string,
 ) error {
 	if rtpAddress != ":0" {
 		l1 := &clientUDPListener{
-			c:                 cm.c,
-			multicastEnable:   multicastEnable,
-			multicastSourceIP: multicastSourceIP,
-			address:           rtpAddress,
+			c:                  cm.c,
+			multicast:          multicast,
+			multicastInterface: multicastInterface,
+			address:            rtpAddress,
 		}
 		err := l1.initialize()
 		if err != nil {
@@ -119,10 +119,10 @@ func (cm *clientMedia) createUDPListeners(
 		}
 
 		l2 := &clientUDPListener{
-			c:                 cm.c,
-			multicastEnable:   multicastEnable,
-			multicastSourceIP: multicastSourceIP,
-			address:           rtcpAddress,
+			c:                  cm.c,
+			multicast:          multicast,
+			multicastInterface: multicastInterface,
+			address:            rtcpAddress,
 		}
 		err = l2.initialize()
 		if err != nil {
@@ -146,10 +146,8 @@ func (cm *clientMedia) createUDPListeners(
 		rtcpPort := rtpPort + 1
 
 		cm.udpRTPListener = &clientUDPListener{
-			c:                 cm.c,
-			multicastEnable:   false,
-			multicastSourceIP: nil,
-			address:           net.JoinHostPort("", strconv.FormatInt(int64(rtpPort), 10)),
+			c:       cm.c,
+			address: net.JoinHostPort("", strconv.FormatInt(int64(rtpPort), 10)),
 		}
 		err = cm.udpRTPListener.initialize()
 		if err != nil {
@@ -158,10 +156,8 @@ func (cm *clientMedia) createUDPListeners(
 		}
 
 		cm.udpRTCPListener = &clientUDPListener{
-			c:                 cm.c,
-			multicastEnable:   false,
-			multicastSourceIP: nil,
-			address:           net.JoinHostPort("", strconv.FormatInt(int64(rtcpPort), 10)),
+			c:       cm.c,
+			address: net.JoinHostPort("", strconv.FormatInt(int64(rtcpPort), 10)),
 		}
 		err = cm.udpRTCPListener.initialize()
 		if err != nil {

--- a/client_udp_listener.go
+++ b/client_udp_listener.go
@@ -29,10 +29,10 @@ type packetConn interface {
 }
 
 type clientUDPListener struct {
-	c                 *Client
-	multicastEnable   bool
-	multicastSourceIP net.IP
-	address           string
+	c                  *Client
+	multicast          bool
+	multicastInterface *net.Interface
+	address            string
 
 	pc        packetConn
 	readFunc  readFunc
@@ -47,13 +47,9 @@ type clientUDPListener struct {
 }
 
 func (u *clientUDPListener) initialize() error {
-	if u.multicastEnable {
-		intf, err := multicast.InterfaceForSource(u.multicastSourceIP)
-		if err != nil {
-			return err
-		}
-
-		u.pc, err = multicast.NewSingleConn(intf, u.address, u.c.ListenPacket)
+	if u.multicast {
+		var err error
+		u.pc, err = multicast.NewSingleConn(u.multicastInterface, u.address, u.c.ListenPacket)
 		if err != nil {
 			return err
 		}

--- a/pkg/multicast/multicast.go
+++ b/pkg/multicast/multicast.go
@@ -13,6 +13,8 @@ type Conn interface {
 }
 
 // InterfaceForSource returns a multicast-capable interface that can communicate with given IP.
+//
+// Deprecated: not used anymore.
 func InterfaceForSource(ip net.IP) (*net.Interface, error) {
 	if ip.Equal(net.ParseIP("127.0.0.1")) {
 		return nil, fmt.Errorf("IP 127.0.0.1 can't be used as source of a multicast stream. Use the LAN IP of your PC")


### PR DESCRIPTION
Fixes #762

this fixes most errors "found no interface that is multicast-capable and can communicate with IP".