### PR TITLE
add windows support

### DIFF
--- a/client_udp_listener.go
+++ b/client_udp_listener.go
@@ -2,7 +2,6 @@ package gortsplib
 
 import (
 	"crypto/rand"
-	"fmt"
 	"math/big"
 	"net"
 	"sync/atomic"
@@ -28,42 +27,6 @@ func randInRange(maxVal int) (int, error) {
 type packetConn interface {
 	net.PacketConn
 	SyscallConn() (syscall.RawConn, error)
-}
-
-func setAndVerifyReadBufferSize(pc packetConn, v int) error {
-	rawConn, err := pc.SyscallConn()
-	if err != nil {
-		panic(err)
-	}
-
-	var err2 error
-
-	err = rawConn.Control(func(fd uintptr) {
-		err2 = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, v)
-		if err2 != nil {
-			return
-		}
-
-		var v2 int
-		v2, err2 = syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
-		if err2 != nil {
-			return
-		}
-
-		if v2 != (v * 2) {
-			err2 = fmt.Errorf("unable to set read buffer size to %v - check that net.core.rmem_max is greater than %v", v, v)
-			return
-		}
-	})
-	if err != nil {
-		return err
-	}
-
-	if err2 != nil {
-		return err2
-	}
-
-	return nil
 }
 
 type clientUDPListener struct {

--- a/client_udp_listener_unix.go
+++ b/client_udp_listener_unix.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package gortsplib
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func setAndVerifyReadBufferSize(pc packetConn, v int) error {
+	rawConn, err := pc.SyscallConn()
+	if err != nil {
+		panic(err)
+	}
+
+	var err2 error
+
+	err = rawConn.Control(func(fd uintptr) {
+		// On Unix-like systems, syscall.SetsockoptInt expects int
+		err2 = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, v)
+		if err2 != nil {
+			return
+		}
+
+		var v2 int
+		v2, err2 = syscall.GetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+		if err2 != nil {
+			return
+		}
+
+		if v2 != (v * 2) {
+			err2 = fmt.Errorf("unable to set read buffer size to %v - check that net.core.rmem_max is greater than %v", v, v)
+			return
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	if err2 != nil {
+		return err2
+	}
+
+	return nil
+}

--- a/client_udp_listener_windows.go
+++ b/client_udp_listener_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package gortsplib
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func setAndVerifyReadBufferSize(pc packetConn, v int) error {
+	rawConn, err := pc.SyscallConn()
+	if err != nil {
+		panic(err)
+	}
+
+	var err2 error
+
+	err = rawConn.Control(func(fd uintptr) {
+		// On Windows, syscall.SetsockoptInt expects syscall.Handle
+		handle := syscall.Handle(fd)
+		err2 = syscall.SetsockoptInt(handle, syscall.SOL_SOCKET, syscall.SO_RCVBUF, v)
+		if err2 != nil {
+			return
+		}
+
+		var v2 int
+		v2, err2 = syscall.GetsockoptInt(handle, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+		if err2 != nil {
+			return
+		}
+
+		if v2 != (v * 2) {
+			err2 = fmt.Errorf("unable to set read buffer size to %v - check that net.core.rmem_max is greater than %v", v, v)
+			return
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	if err2 != nil {
+		return err2
+	}
+
+	return nil
+}


### PR DESCRIPTION
I needed to build for windows and ran into the following error: 

`client_udp_listener.go:48:36: cannot use int(fd) (value of type int) as syscall.Handle value in argument to syscall.GetsockoptInt`

This was encountered on go version "go1.24.6 linux/amd64"

This fix adds handling for both Unix and Windows systems.