### PR TITLE
Fix typo when identifying KLV packets as SMPTE336M-encoded

### DIFF
--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -190,7 +190,7 @@ func Unmarshal(md *psdp.MediaDescription, payloadTypeStr string) (Format, error)
 
 		// other
 
-		case codec == "smtpe336m" && payloadType >= 96 && payloadType <= 127:
+		case codec == "smpte336m" && payloadType >= 96 && payloadType <= 127:
 			return &KLV{}
 
 		/*

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -1193,12 +1193,12 @@ var casesFormat = []struct {
 		"v=0\n" +
 			"s=\n" +
 			"m=application 0 RTP/AVP 97\n" +
-			"a=rtpmap:97 smtpe336m/90000\n",
+			"a=rtpmap:97 SMPTE336M/90000\n",
 		&KLV{
 			PayloadTyp: 97,
 		},
 		97,
-		"smtpe336m/90000",
+		"SMPTE336M/90000",
 		nil,
 	},
 	{

--- a/pkg/format/klv.go
+++ b/pkg/format/klv.go
@@ -34,7 +34,7 @@ func (f *KLV) PayloadType() uint8 {
 
 // RTPMap implements Format.
 func (f *KLV) RTPMap() string {
-	return "smtpe336m/90000"
+	return "SMPTE336M/90000"
 }
 
 // FMTP implements Format.

--- a/pkg/headers/range_test.go
+++ b/pkg/headers/range_test.go
@@ -145,7 +145,7 @@ func FuzzRangeUnmarshal(f *testing.F) {
 		f.Add(ca.vin[0])
 	}
 
-	f.Add("smtpe=")
+	f.Add("smpte=")
 	f.Add("npt=")
 	f.Add("clock=")
 


### PR DESCRIPTION
Fixes https://github.com/bluenviron/mediamtx/issues/4848

The encoding name used to identify and mark KLV packets appropriately was typo'd in a few places as "smtpe" ("tpe" vs "pte"). This was causing downstream consumers (including ffmpeg and gstreamer) to not properly identify KLV data streams, and may have caused issues with mediamtx itself identifying KLV data streams (unconfirmed). This typo was introduced in https://github.com/bluenviron/gortsplib/pull/808

This PR fixes the typo and adjusts casing to stay consistent with other encoding-name mappings in this library.

# Testing

We tested this fix locally by serving an MPEGTS file with KLV data via an RTSP stream directly in mediamtx and receiving the stream in gstreamer:

```
gst-launch-1.0 rtspsrc location="rtsp://127.0.0.1:8554/stream" ! rtpklvdepay ! fakesink
```

The `rtpklvdepay` element successfully identifies KLV packets from the stream after this fix.