### PR TITLE
client: remove automatic SNI support

### DIFF
--- a/client.go
+++ b/client.go
@@ -1188,11 +1188,6 @@ func (c *Client) connOpen() error {
 		if tlsConfig == nil {
 			tlsConfig = &tls.Config{}
 		}
-		tlsConfig.ServerName = (&base.URL{
-			Scheme: c.Scheme,
-			Host:   c.Host,
-		}).Hostname()
-
 		nconn = tls.Client(nconn, tlsConfig)
 	}
 


### PR DESCRIPTION
SNI support should be enabled by properly filling TLSConfig.