### PR TITLE
server: fix timeout when recording with FFmpeg and UDP (bluenviron/mediamtx#5100)

### DIFF
--- a/server_conn_reader.go
+++ b/server_conn_reader.go
@@ -204,7 +204,13 @@ func (cr *serverConnReader) handleTunneling(in io.ReadWriter) (io.ReadWriter, er
 
 func (cr *serverConnReader) readFuncStandard() error {
 	for {
-		cr.sc.nconn.SetReadDeadline(time.Now().Add(cr.sc.s.IdleTimeout))
+		// when FFmpeg is recording with UDP, it does not send keepalives, no matter what.
+		// disable read deadline.
+		if cr.sc.session != nil && cr.sc.session.state == ServerSessionStateRecord {
+			cr.sc.nconn.SetReadDeadline(time.Time{})
+		} else {
+			cr.sc.nconn.SetReadDeadline(time.Now().Add(cr.sc.s.IdleTimeout))
+		}
 
 		what, err := cr.sc.conn.Read()
 		if err != nil {

--- a/server_record_test.go
+++ b/server_record_test.go
@@ -585,7 +585,7 @@ func TestServerRecord(t *testing.T) {
 					onConnClose: func(ctx *ServerHandlerOnConnCloseCtx) {
 						s := ctx.Conn.Stats()
 						require.Greater(t, s.BytesSent, uint64(510))
-						require.Less(t, s.BytesSent, uint64(1100))
+						require.Less(t, s.BytesSent, uint64(1150))
 						require.Greater(t, s.BytesReceived, uint64(1000))
 						require.Less(t, s.BytesReceived, uint64(1800))
 

--- a/server_session.go
+++ b/server_session.go
@@ -884,19 +884,7 @@ func (ss *ServerSession) runInner() error {
 
 					res.Header["Session"] = headers.Session{
 						Session: ss.secretID,
-						Timeout: func() *uint {
-							// timeout controls the sending of RTCP keepalives.
-							// these are needed only when the client is playing
-							// and transport is UDP or UDP-multicast.
-							if (ss.state == ServerSessionStatePrePlay ||
-								ss.state == ServerSessionStatePlay) &&
-								(ss.setuppedTransport.Protocol == ProtocolUDP ||
-									ss.setuppedTransport.Protocol == ProtocolUDPMulticast) {
-								v := uint(ss.s.IdleTimeout / time.Second)
-								return &v
-							}
-							return nil
-						}(),
+						Timeout: ptrOf(uint(ss.s.IdleTimeout / time.Second)),
 					}.Marshal()
 				}
 


### PR DESCRIPTION
Fixes bluenviron/mediamtx#5100