### PR TITLE
server: add NetListener() (#833)

### DIFF
--- a/server.go
+++ b/server.go
@@ -362,6 +362,11 @@ func (s *Server) Wait() error {
 	return s.closeError
 }
 
+// NetListener returns the underlying net.Listener
+func (s *Server) NetListener() net.Listener {
+	return s.tcpListener.ln
+}
+
 func (s *Server) run() {
 	defer s.wg.Done()
 

--- a/server_test.go
+++ b/server_test.go
@@ -240,6 +240,20 @@ func TestServerClose(t *testing.T) {
 	s.Close()
 }
 
+func TestServerNetListener(t *testing.T) {
+	s := &Server{
+		Handler:     &testServerHandler{},
+		RTSPAddress: "127.0.0.1:8554",
+	}
+
+	err := s.Start()
+	require.NoError(t, err)
+	defer s.Close()
+
+	ln := s.NetListener()
+	require.Equal(t, "127.0.0.1:8554", ln.Addr().String())
+}
+
 func TestServerErrorInvalidUDPPorts(t *testing.T) {
 	t.Run("non consecutive", func(t *testing.T) {
 		s := &Server{


### PR DESCRIPTION
Fixes #833 

this allows to obtain the underlying net.Listener.