### PR TITLE
Add dialer for existing WebSocket connection

### DIFF
--- a/client_tunnel_websocket.go
+++ b/client_tunnel_websocket.go
@@ -48,6 +48,19 @@ func (tu *clientTunnelWebSocket) SetWriteDeadline(t time.Time) error {
 	return tu.wconn.SetWriteDeadline(t)
 }
 
+// MakeWebSoketDial make a dialer from WebSocket connection.
+func MakeWebSoketDial(
+	conn *websocket.Conn,
+) func(ctx context.Context, network, address string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		return &clientTunnelWebSocket{
+			wconn: conn,
+			r:     &wsReader{wc: conn},
+			w:     &wsWriter{wc: conn},
+		}, nil
+	}
+}
+
 func newClientTunnelWebSocket(
 	ctx context.Context,
 	dialContext func(ctx context.Context, network, address string) (net.Conn, error),


### PR DESCRIPTION
Sometimes, it is impossible to connect to RTSP-server and pulling media stream due to NAT as an example. WebSocket tunnel from RTSP-server allows RTSP-client to dial to RTSP-server via WS tunnel. However, public API of the library does not allow to do it. This PR solves the issue.