### PR TITLE
Introduce AnyPortUseTCP option to Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -476,6 +476,10 @@ type Client struct {
 	// This can be a security issue.
 	// It defaults to false.
 	AnyPortEnable bool
+	// If transport protocol is chosen automatically,
+	// switch to TCP transport protocol if a server doesn't provide UDP server ports.
+	// It defaults to false.
+	AnyPortUseTCP bool
 	// If the client is reading with UDP, it must receive
 	// at least a packet within this timeout, otherwise it switches to TCP.
 	// It defaults to 3 seconds.
@@ -1855,7 +1859,6 @@ func (c *Client) doSetup(
 				Protocol: ProtocolTCP,
 				Profile:  th.Profile,
 			}
-
 			return c.doSetup(baseURL, medi, 0, 0)
 		}
 
@@ -1875,31 +1878,29 @@ func (c *Client) doSetup(
 		return nil, liberrors.ErrClientTransportHeaderInvalid{Err: err}
 	}
 
+	switchToTCP := func(switchErr error) (*base.Response, error) {
+		c.OnTransportSwitch(switchErr)
+		c.baseURL = baseURL
+		c.reset()
+		c.setuppedTransport = &SessionTransport{
+			Protocol: ProtocolTCP,
+			Profile:  th.Profile,
+		}
+		// some Hikvision cameras require a describe before a setup
+		_, _, err = c.doDescribe(c.lastDescribeURL)
+		if err != nil {
+			return nil, err
+		}
+		return c.doSetup(baseURL, medi, 0, 0)
+	}
+
 	switch protocol {
 	case ProtocolUDP, ProtocolUDPMulticast:
 		if thRes.Protocol == headers.TransportProtocolTCP {
 			// switch transport automatically
 			if c.setuppedTransport == nil && c.Protocol == nil {
-				c.OnTransportSwitch(liberrors.ErrClientSwitchToTCP2{})
-
-				c.baseURL = baseURL
-
-				c.reset()
-
-				c.setuppedTransport = &SessionTransport{
-					Protocol: ProtocolTCP,
-					Profile:  th.Profile,
-				}
-
-				// some Hikvision cameras require a describe before a setup
-				_, _, err = c.doDescribe(c.lastDescribeURL)
-				if err != nil {
-					return nil, err
-				}
-
-				return c.doSetup(baseURL, medi, 0, 0)
+				return switchToTCP(liberrors.ErrClientSwitchToTCP2{})
 			}
-
 			return nil, liberrors.ErrClientServerRequestedTCP{}
 		}
 	}
@@ -1911,9 +1912,13 @@ func (c *Client) doSetup(
 		}
 
 		serverPortsValid := thRes.ServerPorts != nil && !isAnyPort(thRes.ServerPorts[0]) && !isAnyPort(thRes.ServerPorts[1])
-
-		if (c.state == clientStatePreRecord || !c.AnyPortEnable) && !serverPortsValid {
-			return nil, liberrors.ErrClientServerPortsNotProvided{}
+		if !serverPortsValid {
+			if c.AnyPortUseTCP && c.setuppedTransport == nil && c.Protocol == nil {
+				return switchToTCP(liberrors.ErrClientSwitchToTCP3{})
+			}
+			if c.state == clientStatePreRecord || !c.AnyPortEnable {
+				return nil, liberrors.ErrClientServerPortsNotProvided{}
+			}
 		}
 
 		var remoteIP net.IP

--- a/client_play_test.go
+++ b/client_play_test.go
@@ -1799,7 +1799,7 @@ func TestClientPlayAutomaticProtocol(t *testing.T) {
 				require.Error(t, err2)
 			}()
 
-			func() {
+			func() { //nolint:dupl
 				nconn, err2 := l.Accept()
 				require.NoError(t, err2)
 				defer nconn.Close()
@@ -2119,6 +2119,180 @@ func TestClientPlayAutomaticProtocol(t *testing.T) {
 		}
 
 		err = readAll(&c, "rtsp://myuser:mypass@localhost:8554/teststream",
+			func(_ *description.Media, _ format.Format, _ *rtp.Packet) {
+				close(packetRecv)
+			})
+		require.NoError(t, err)
+		defer c.Close()
+
+		<-msgRecv
+		<-packetRecv
+	})
+
+	t.Run("switch after no udp server ports", func(t *testing.T) {
+		l, err := net.Listen("tcp", "localhost:8554")
+		require.NoError(t, err)
+		defer l.Close()
+
+		serverDone := make(chan struct{})
+		defer func() { <-serverDone }()
+
+		go func() {
+			defer close(serverDone)
+
+			medias := []*description.Media{testH264Media}
+
+			func() {
+				nconn, err2 := l.Accept()
+				require.NoError(t, err2)
+				defer nconn.Close()
+				co := conn.NewConn(bufio.NewReader(nconn), nconn)
+
+				req, err2 := co.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Options, req.Method)
+
+				err2 = co.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Public": base.HeaderValue{strings.Join([]string{
+							string(base.Describe),
+							string(base.Setup),
+							string(base.Play),
+						}, ", ")},
+					},
+				})
+				require.NoError(t, err2)
+
+				req, err2 = co.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Describe, req.Method)
+
+				err2 = co.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Content-Type": base.HeaderValue{"application/sdp"},
+						"Content-Base": base.HeaderValue{"rtsp://localhost:8554/teststream/"},
+					},
+					Body: mediasToSDP(medias),
+				})
+				require.NoError(t, err2)
+
+				req, err2 = co.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Setup, req.Method)
+
+				err2 = co.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Transport": headers.Transport{
+							Protocol:       headers.TransportProtocolUDP,
+							Delivery:       ptrOf(headers.TransportDeliveryUnicast),
+							InterleavedIDs: &[2]int{0, 1},
+						}.Marshal(),
+					},
+				})
+				require.NoError(t, err2)
+
+				req, err2 = co.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Teardown, req.Method)
+
+				err2 = co.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+				})
+				require.NoError(t, err2)
+
+				_, err2 = co.ReadRequest()
+				require.Error(t, err2)
+			}()
+
+			func() { //nolint:dupl
+				nconn, err2 := l.Accept()
+				require.NoError(t, err2)
+				defer nconn.Close()
+				co := conn.NewConn(bufio.NewReader(nconn), nconn)
+
+				req, err2 := co.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Options, req.Method)
+
+				err2 = co.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Public": base.HeaderValue{strings.Join([]string{
+							string(base.Describe),
+							string(base.Setup),
+							string(base.Play),
+						}, ", ")},
+					},
+				})
+				require.NoError(t, err2)
+
+				req, err2 = co.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Describe, req.Method)
+
+				err2 = co.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Content-Type": base.HeaderValue{"application/sdp"},
+						"Content-Base": base.HeaderValue{"rtsp://localhost:8554/teststream/"},
+					},
+					Body: mediasToSDP(medias),
+				})
+				require.NoError(t, err2)
+
+				req, err2 = co.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Setup, req.Method)
+
+				var inTH headers.Transport
+				err2 = inTH.Unmarshal(req.Header["Transport"])
+				require.NoError(t, err2)
+				require.Equal(t, headers.TransportProtocolTCP, inTH.Protocol)
+
+				err2 = co.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Transport": headers.Transport{
+							Protocol:       headers.TransportProtocolTCP,
+							Delivery:       ptrOf(headers.TransportDeliveryUnicast),
+							InterleavedIDs: &[2]int{0, 1},
+						}.Marshal(),
+					},
+				})
+				require.NoError(t, err2)
+
+				req, err2 = co.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Play, req.Method)
+
+				err2 = co.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+				})
+				require.NoError(t, err2)
+
+				err2 = co.WriteInterleavedFrame(&base.InterleavedFrame{
+					Channel: 0,
+					Payload: testRTPPacketMarshaled,
+				}, make([]byte, 1024))
+				require.NoError(t, err2)
+			}()
+		}()
+
+		msgRecv := make(chan struct{})
+		packetRecv := make(chan struct{})
+
+		c := Client{
+			AnyPortUseTCP: true,
+			OnTransportSwitch: func(err error) {
+				require.EqualError(t, err, "no UDP server ports provided, switching to TCP")
+				close(msgRecv)
+			},
+		}
+
+		err = readAll(&c, "rtsp://localhost:8554/teststream",
 			func(_ *description.Media, _ format.Format, _ *rtp.Packet) {
 				close(packetRecv)
 			})

--- a/pkg/liberrors/client.go
+++ b/pkg/liberrors/client.go
@@ -295,6 +295,14 @@ func (e ErrClientSwitchToTCP2) Error() string {
 	return "switching to TCP because server requested it"
 }
 
+// ErrClientSwitchToTCP3 is an error that can be returned by a client.
+type ErrClientSwitchToTCP3 struct{}
+
+// Error implements the error interface.
+func (e ErrClientSwitchToTCP3) Error() string {
+	return "no UDP server ports provided, switching to TCP"
+}
+
 // ErrClientAuthSetup is an error that can be returned by a client.
 type ErrClientAuthSetup struct {
 	Err error


### PR DESCRIPTION
Introduce an option to Client that will make it switch to TCP when a server doesn't return any UDP ports.