### PR TITLE
Handle SDP ConnectionInformation missing IP4/IP6 address type

### DIFF
--- a/pkg/sdp/sdp.go
+++ b/pkg/sdp/sdp.go
@@ -4,6 +4,7 @@ package sdp
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"slices"
 	"strconv"
@@ -202,6 +203,19 @@ func unmarshalConnectionInformation(value string) (*psdp.ConnectionInformation, 
 	fields := strings.Fields(value)
 	if len(fields) < 2 {
 		return nil, fmt.Errorf("%w `c=%v`", errSDPInvalidSyntax, fields)
+	}
+
+	// Tolerate malformed lines like:
+	// c=IN 192.168.4.232
+	// c=IN fe80::1234
+	if len(fields) == 2 && strings.EqualFold(fields[0], "IN") {
+		if ip := net.ParseIP(fields[1]); ip != nil {
+			addrType := "IP6"
+			if ip.To4() != nil {
+				addrType = "IP4"
+			}
+			fields = []string{"IN", addrType, fields[1]}
+		}
 	}
 
 	// Set according to currently registered with IANA

--- a/pkg/sdp/sdp_test.go
+++ b/pkg/sdp/sdp_test.go
@@ -388,6 +388,108 @@ var cases = []struct {
 		},
 	},
 	{
+		"missing c= address type ipv4",
+		[]byte("v=0\r\n" +
+			"o=test 123 456 IN IP4 192.0.2.1\r\n" +
+			"s=Test SDP\r\n" +
+			"c=IN 198.51.100.1\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n"),
+		[]byte("v=0\r\n" +
+			"o=test 123 456 IN IP4 192.0.2.1\r\n" +
+			"s=Test SDP\r\n" +
+			"c=IN IP4 198.51.100.1\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n"),
+		SessionDescription{
+			Origin: psdp.Origin{
+				Username:       "test",
+				SessionID:      123,
+				SessionVersion: 456,
+				NetworkType:    "IN",
+				AddressType:    "IP4",
+				UnicastAddress: "192.0.2.1",
+			},
+			SessionName: "Test SDP",
+			ConnectionInformation: &psdp.ConnectionInformation{
+				NetworkType: "IN",
+				AddressType: "IP4",
+				Address: &psdp.Address{
+					Address: "198.51.100.1",
+				},
+			},
+			TimeDescriptions: []psdp.TimeDescription{
+				{
+					Timing: psdp.Timing{
+						StartTime: 0,
+						StopTime:  0,
+					},
+				},
+			},
+			MediaDescriptions: []*psdp.MediaDescription{
+				{
+					MediaName: psdp.MediaName{
+						Media:   "video",
+						Port:    psdp.RangedPort{Value: 0},
+						Protos:  []string{"RTP", "AVP"},
+						Formats: []string{"96"},
+					},
+				},
+			},
+		},
+	},
+	{
+		"missing c= address type ipv6",
+		[]byte("v=0\r\n" +
+			"o=test 123 456 IN IP6 2001:db8::1\r\n" +
+			"s=Test SDP\r\n" +
+			"c=IN 2001:db8::2\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n"),
+		[]byte("v=0\r\n" +
+			"o=test 123 456 IN IP6 2001:db8::1\r\n" +
+			"s=Test SDP\r\n" +
+			"c=IN IP6 2001:db8::2\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n"),
+		SessionDescription{
+			Origin: psdp.Origin{
+				Username:       "test",
+				SessionID:      123,
+				SessionVersion: 456,
+				NetworkType:    "IN",
+				AddressType:    "IP6",
+				UnicastAddress: "2001:db8::1",
+			},
+			SessionName: "Test SDP",
+			ConnectionInformation: &psdp.ConnectionInformation{
+				NetworkType: "IN",
+				AddressType: "IP6",
+				Address: &psdp.Address{
+					Address: "2001:db8::2",
+				},
+			},
+			TimeDescriptions: []psdp.TimeDescription{
+				{
+					Timing: psdp.Timing{
+						StartTime: 0,
+						StopTime:  0,
+					},
+				},
+			},
+			MediaDescriptions: []*psdp.MediaDescription{
+				{
+					MediaName: psdp.MediaName{
+						Media:   "video",
+						Port:    psdp.RangedPort{Value: 0},
+						Protos:  []string{"RTP", "AVP"},
+						Formats: []string{"96"},
+					},
+				},
+			},
+		},
+	},
+	{
 		"no timing",
 		[]byte("v=0\r\n" +
 			"o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\r\n" +

--- a/pkg/sdp/sdp_test.go
+++ b/pkg/sdp/sdp_test.go
@@ -388,108 +388,6 @@ var cases = []struct {
 		},
 	},
 	{
-		"missing c= address type ipv4",
-		[]byte("v=0\r\n" +
-			"o=test 123 456 IN IP4 192.0.2.1\r\n" +
-			"s=Test SDP\r\n" +
-			"c=IN 198.51.100.1\r\n" +
-			"t=0 0\r\n" +
-			"m=video 0 RTP/AVP 96\r\n"),
-		[]byte("v=0\r\n" +
-			"o=test 123 456 IN IP4 192.0.2.1\r\n" +
-			"s=Test SDP\r\n" +
-			"c=IN IP4 198.51.100.1\r\n" +
-			"t=0 0\r\n" +
-			"m=video 0 RTP/AVP 96\r\n"),
-		SessionDescription{
-			Origin: psdp.Origin{
-				Username:       "test",
-				SessionID:      123,
-				SessionVersion: 456,
-				NetworkType:    "IN",
-				AddressType:    "IP4",
-				UnicastAddress: "192.0.2.1",
-			},
-			SessionName: "Test SDP",
-			ConnectionInformation: &psdp.ConnectionInformation{
-				NetworkType: "IN",
-				AddressType: "IP4",
-				Address: &psdp.Address{
-					Address: "198.51.100.1",
-				},
-			},
-			TimeDescriptions: []psdp.TimeDescription{
-				{
-					Timing: psdp.Timing{
-						StartTime: 0,
-						StopTime:  0,
-					},
-				},
-			},
-			MediaDescriptions: []*psdp.MediaDescription{
-				{
-					MediaName: psdp.MediaName{
-						Media:   "video",
-						Port:    psdp.RangedPort{Value: 0},
-						Protos:  []string{"RTP", "AVP"},
-						Formats: []string{"96"},
-					},
-				},
-			},
-		},
-	},
-	{
-		"missing c= address type ipv6",
-		[]byte("v=0\r\n" +
-			"o=test 123 456 IN IP6 2001:db8::1\r\n" +
-			"s=Test SDP\r\n" +
-			"c=IN 2001:db8::2\r\n" +
-			"t=0 0\r\n" +
-			"m=video 0 RTP/AVP 96\r\n"),
-		[]byte("v=0\r\n" +
-			"o=test 123 456 IN IP6 2001:db8::1\r\n" +
-			"s=Test SDP\r\n" +
-			"c=IN IP6 2001:db8::2\r\n" +
-			"t=0 0\r\n" +
-			"m=video 0 RTP/AVP 96\r\n"),
-		SessionDescription{
-			Origin: psdp.Origin{
-				Username:       "test",
-				SessionID:      123,
-				SessionVersion: 456,
-				NetworkType:    "IN",
-				AddressType:    "IP6",
-				UnicastAddress: "2001:db8::1",
-			},
-			SessionName: "Test SDP",
-			ConnectionInformation: &psdp.ConnectionInformation{
-				NetworkType: "IN",
-				AddressType: "IP6",
-				Address: &psdp.Address{
-					Address: "2001:db8::2",
-				},
-			},
-			TimeDescriptions: []psdp.TimeDescription{
-				{
-					Timing: psdp.Timing{
-						StartTime: 0,
-						StopTime:  0,
-					},
-				},
-			},
-			MediaDescriptions: []*psdp.MediaDescription{
-				{
-					MediaName: psdp.MediaName{
-						Media:   "video",
-						Port:    psdp.RangedPort{Value: 0},
-						Protos:  []string{"RTP", "AVP"},
-						Formats: []string{"96"},
-					},
-				},
-			},
-		},
-	},
-	{
 		"no timing",
 		[]byte("v=0\r\n" +
 			"o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\r\n" +
@@ -3337,6 +3235,108 @@ var cases = []struct {
 							Key:   "recvonly",
 							Value: "",
 						},
+					},
+				},
+			},
+		},
+	},
+	{
+		"issue gortsplib/1025 (undisclosed cameras, ipv4)",
+		[]byte("v=0\r\n" +
+			"o=test 123 456 IN IP4 192.0.2.1\r\n" +
+			"s=Test SDP\r\n" +
+			"c=IN 198.51.100.1\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n"),
+		[]byte("v=0\r\n" +
+			"o=test 123 456 IN IP4 192.0.2.1\r\n" +
+			"s=Test SDP\r\n" +
+			"c=IN IP4 198.51.100.1\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n"),
+		SessionDescription{
+			Origin: psdp.Origin{
+				Username:       "test",
+				SessionID:      123,
+				SessionVersion: 456,
+				NetworkType:    "IN",
+				AddressType:    "IP4",
+				UnicastAddress: "192.0.2.1",
+			},
+			SessionName: "Test SDP",
+			ConnectionInformation: &psdp.ConnectionInformation{
+				NetworkType: "IN",
+				AddressType: "IP4",
+				Address: &psdp.Address{
+					Address: "198.51.100.1",
+				},
+			},
+			TimeDescriptions: []psdp.TimeDescription{
+				{
+					Timing: psdp.Timing{
+						StartTime: 0,
+						StopTime:  0,
+					},
+				},
+			},
+			MediaDescriptions: []*psdp.MediaDescription{
+				{
+					MediaName: psdp.MediaName{
+						Media:   "video",
+						Port:    psdp.RangedPort{Value: 0},
+						Protos:  []string{"RTP", "AVP"},
+						Formats: []string{"96"},
+					},
+				},
+			},
+		},
+	},
+	{
+		"issue gortsplib/1025 (undisclosed cameras, ipv6)",
+		[]byte("v=0\r\n" +
+			"o=test 123 456 IN IP6 2001:db8::1\r\n" +
+			"s=Test SDP\r\n" +
+			"c=IN 2001:db8::2\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n"),
+		[]byte("v=0\r\n" +
+			"o=test 123 456 IN IP6 2001:db8::1\r\n" +
+			"s=Test SDP\r\n" +
+			"c=IN IP6 2001:db8::2\r\n" +
+			"t=0 0\r\n" +
+			"m=video 0 RTP/AVP 96\r\n"),
+		SessionDescription{
+			Origin: psdp.Origin{
+				Username:       "test",
+				SessionID:      123,
+				SessionVersion: 456,
+				NetworkType:    "IN",
+				AddressType:    "IP6",
+				UnicastAddress: "2001:db8::1",
+			},
+			SessionName: "Test SDP",
+			ConnectionInformation: &psdp.ConnectionInformation{
+				NetworkType: "IN",
+				AddressType: "IP6",
+				Address: &psdp.Address{
+					Address: "2001:db8::2",
+				},
+			},
+			TimeDescriptions: []psdp.TimeDescription{
+				{
+					Timing: psdp.Timing{
+						StartTime: 0,
+						StopTime:  0,
+					},
+				},
+			},
+			MediaDescriptions: []*psdp.MediaDescription{
+				{
+					MediaName: psdp.MediaName{
+						Media:   "video",
+						Port:    psdp.RangedPort{Value: 0},
+						Protos:  []string{"RTP", "AVP"},
+						Formats: []string{"96"},
 					},
 				},
 			},


### PR DESCRIPTION
Some RTSP devices generate malformed SDP connection information that causes parsing failures in MediaMTX.

For example:
ERR [path test] [RTSP source] invalid SDP: sdp: invalid syntax `c=IN 192.168.4.27`

This change tolerates these cases by inferring the address type using net.ParseIP().

This also includes test cases for both IPv4 and IPv6.