### PR TITLE
client: don't block RTSP-over-HTTP tunnel startup on POST response

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -878,25 +878,6 @@ func TestClientTunnelHTTPPostResponseAfterRTSPRequest(t *testing.T) {
 				scheme = schemeRTSPS
 			}
 
-			writePostResponse := func(nconn net.Conn, protoMinor int) {
-				h := http.Header{}
-				h.Set("Cache-Control", "no-cache")
-				h.Set("Connection", "close")
-				h.Set("Content-Type", "application/x-rtsp-tunnelled")
-				h.Set("Pragma", "no-cache")
-				res := http.Response{
-					StatusCode:    http.StatusOK,
-					ProtoMajor:    1,
-					ProtoMinor:    protoMinor,
-					Header:        h,
-					ContentLength: -1,
-				}
-				var resBuf bytes.Buffer
-				res.Write(&resBuf) //nolint:errcheck
-				_, err2 := nconn.Write(resBuf.Bytes())
-				require.NoError(t, err2)
-			}
-
 			serverDone := make(chan struct{})
 			defer func() { <-serverDone }()
 
@@ -984,7 +965,22 @@ func TestClientTunnelHTTPPostResponseAfterRTSPRequest(t *testing.T) {
 				require.NoError(t, err2)
 				require.Equal(t, base.Options, req.Method)
 
-				writePostResponse(nconn2, req1.ProtoMinor)
+				h = http.Header{}
+				h.Set("Cache-Control", "no-cache")
+				h.Set("Connection", "close")
+				h.Set("Content-Type", "application/x-rtsp-tunnelled")
+				h.Set("Pragma", "no-cache")
+				res = http.Response{
+					StatusCode:    http.StatusOK,
+					ProtoMajor:    1,
+					ProtoMinor:    req1.ProtoMinor,
+					Header:        h,
+					ContentLength: -1,
+				}
+				resBuf.Reset()
+				res.Write(&resBuf) //nolint:errcheck
+				_, err2 = nconn2.Write(resBuf.Bytes())
+				require.NoError(t, err2)
 
 				err2 = conn.WriteResponse(&base.Response{
 					StatusCode: base.StatusOK,

--- a/client_test.go
+++ b/client_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -828,6 +829,199 @@ func TestClientTunnelHTTP(t *testing.T) {
 				Scheme: u.Scheme,
 				Host:   u.Host,
 				Tunnel: TunnelHTTP,
+				TLSConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			}
+
+			err = c.Start()
+			require.NoError(t, err)
+			defer c.Close()
+
+			_, res, err := c.Describe(u)
+			require.NoError(t, err)
+			require.Equal(t, base.StatusOK, res.StatusCode)
+		})
+	}
+}
+
+func TestClientTunnelHTTPPostResponseAfterRTSPRequest(t *testing.T) {
+	for _, ca := range []string{"http", "https"} {
+		t.Run(ca, func(t *testing.T) {
+			var l net.Listener
+			var err error
+
+			if ca == "http" {
+				l, err = net.Listen("tcp", "localhost:8554")
+				require.NoError(t, err)
+				defer l.Close()
+			} else {
+				var cert tls.Certificate
+				cert, err = tls.X509KeyPair(serverCert, serverKey)
+				require.NoError(t, err)
+
+				l, err = tls.Listen("tcp", "localhost:8554", &tls.Config{
+					Certificates: []tls.Certificate{cert},
+					VerifyConnection: func(cs tls.ConnectionState) error {
+						require.Equal(t, "localhost", cs.ServerName)
+						return nil
+					},
+				})
+				require.NoError(t, err)
+				defer l.Close()
+			}
+
+			var scheme string
+			if ca == "http" {
+				scheme = schemeRTSP
+			} else {
+				scheme = schemeRTSPS
+			}
+
+			writePostResponse := func(nconn net.Conn, protoMinor int) {
+				h := http.Header{}
+				h.Set("Cache-Control", "no-cache")
+				h.Set("Connection", "close")
+				h.Set("Content-Type", "application/x-rtsp-tunnelled")
+				h.Set("Pragma", "no-cache")
+				res := http.Response{
+					StatusCode:    http.StatusOK,
+					ProtoMajor:    1,
+					ProtoMinor:    protoMinor,
+					Header:        h,
+					ContentLength: -1,
+				}
+				var resBuf bytes.Buffer
+				res.Write(&resBuf) //nolint:errcheck
+				_, err2 := nconn.Write(resBuf.Bytes())
+				require.NoError(t, err2)
+			}
+
+			serverDone := make(chan struct{})
+			defer func() { <-serverDone }()
+
+			go func() {
+				defer close(serverDone)
+
+				nconn1, err2 := l.Accept()
+				require.NoError(t, err2)
+				defer nconn1.Close()
+
+				buf1 := bufio.NewReader(nconn1)
+				req1, err2 := http.ReadRequest(buf1)
+				require.NoError(t, err2)
+
+				require.Equal(t, &http.Request{
+					Method:     http.MethodGet,
+					Proto:      "HTTP/1.1",
+					ProtoMajor: 1,
+					ProtoMinor: 1,
+					URL: &url.URL{
+						Path: "/teststream",
+					},
+					Host:       "localhost:8554",
+					RequestURI: "/teststream",
+					Header: http.Header{
+						"Accept":          []string{"application/x-rtsp-tunnelled"},
+						"Content-Length":  []string{"30000"},
+						"X-Sessioncookie": req1.Header["X-Sessioncookie"],
+					},
+					ContentLength: 30000,
+					Body:          req1.Body,
+				}, req1)
+
+				require.NotEmpty(t, req1.Header.Get("X-Sessioncookie"))
+
+				h := http.Header{}
+				h.Set("Cache-Control", "no-cache")
+				h.Set("Connection", "close")
+				h.Set("Content-Type", "application/x-rtsp-tunnelled")
+				h.Set("Pragma", "no-cache")
+				res := http.Response{
+					StatusCode:    http.StatusOK,
+					ProtoMajor:    1,
+					ProtoMinor:    req1.ProtoMinor,
+					Header:        h,
+					ContentLength: -1,
+				}
+				var resBuf bytes.Buffer
+				res.Write(&resBuf) //nolint:errcheck
+				_, err = nconn1.Write(resBuf.Bytes())
+				require.NoError(t, err)
+
+				nconn2, err2 := l.Accept()
+				require.NoError(t, err2)
+				defer nconn2.Close()
+
+				buf2 := bufio.NewReader(nconn2)
+				req2, err2 := http.ReadRequest(buf2)
+				require.NoError(t, err2)
+
+				require.Equal(t, &http.Request{
+					Method:     http.MethodPost,
+					Proto:      "HTTP/1.1",
+					ProtoMajor: 1,
+					ProtoMinor: 1,
+					URL: &url.URL{
+						Path: "/teststream",
+					},
+					Host:       "localhost:8554",
+					RequestURI: "/teststream",
+					Header: http.Header{
+						"Content-Type":    []string{"application/x-rtsp-tunnelled"},
+						"Content-Length":  []string{"30000"},
+						"X-Sessioncookie": req2.Header["X-Sessioncookie"],
+					},
+					ContentLength: 30000,
+					Body:          req2.Body,
+				}, req2)
+
+				require.Equal(t, req1.Header.Get("X-Sessioncookie"), req2.Header.Get("X-Sessioncookie"))
+
+				conn := conn.NewConn(bufio.NewReader(base64streamreader.New(buf2)), nconn1)
+
+				req, err2 := conn.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Options, req.Method)
+
+				writePostResponse(nconn2, req1.ProtoMinor)
+
+				err2 = conn.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Public": base.HeaderValue{strings.Join([]string{
+							string(base.Describe),
+						}, ", ")},
+					},
+				})
+				require.NoError(t, err2)
+
+				req, err2 = conn.ReadRequest()
+				require.NoError(t, err2)
+				require.Equal(t, base.Describe, req.Method)
+				require.Equal(t, mustParseURL(scheme+"://localhost:8554/teststream"), req.URL)
+
+				medias := []*description.Media{testH264Media}
+
+				err2 = conn.WriteResponse(&base.Response{
+					StatusCode: base.StatusOK,
+					Header: base.Header{
+						"Content-Type": base.HeaderValue{"application/sdp; charset=utf-8"},
+						"Content-Base": base.HeaderValue{"/relative-content-base"},
+					},
+					Body: mediasToSDP(medias),
+				})
+				require.NoError(t, err2)
+			}()
+
+			u, err := base.ParseURL(scheme + "://localhost:8554/teststream")
+			require.NoError(t, err)
+
+			c := Client{
+				Scheme:      u.Scheme,
+				Host:        u.Host,
+				Tunnel:      TunnelHTTP,
+				ReadTimeout: time.Second,
 				TLSConfig: &tls.Config{
 					InsecureSkipVerify: true,
 				},

--- a/client_tunnel_http.go
+++ b/client_tunnel_http.go
@@ -204,17 +204,6 @@ func newClientTunnelHTTP(
 		return nil, err
 	}
 
-	writeBuf := bufio.NewReader(c.writeChan)
-	res, err = http.ReadResponse(writeBuf, nil)
-	if err != nil {
-		return nil, err
-	}
-	res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("bad status code: %v", res.StatusCode)
-	}
-
 	ok = true
 	return c, nil
 }

--- a/client_tunnel_http.go
+++ b/client_tunnel_http.go
@@ -204,6 +204,8 @@ func newClientTunnelHTTP(
 		return nil, err
 	}
 
+	// do not wait for writeChan response, since some servers don't send it.
+
 	ok = true
 	return c, nil
 }


### PR DESCRIPTION
## Summary

Fix an RTSP-over-HTTP tunnel deadlock by stopping the client from synchronously waiting for the HTTP response to the tunnel `POST` request before sending tunneled RTSP bytes (issue: https://github.com/bluenviron/gortsplib/issues/1045).

Some real servers (e.g., Axis cameras and hor speakers) wait for tunneled RTSP traffic on the `POST` connection before sending the `POST` HTTP response. In that case, the previous behavior could deadlock tunnel establishment:

1. client sends tunnel `GET`
2. client validates `GET 200 OK`
3. client sends tunnel `POST`
4. client waits for the `POST` HTTP response
5. server waits for tunneled RTSP request bytes on the `POST`
6. neither side makes progress

With this patch, the client still validates the `GET` response as before, but after successfully writing the `POST` headers it immediately considers the HTTP tunnel ready and allows RTSP requests like `OPTIONS` / `DESCRIBE` to flow.

## Motivation

This was observed against a real GStreamer-based ONVIF audio endpoint (Axis horn speaker) where:

- the tunnel `GET` receives `200 OK`
- the tunnel `POST` is accepted
- no `POST` HTTP response is sent until tunneled RTSP request bytes arrive
- the client never sends `OPTIONS` / `DESCRIBE` because it is blocked waiting for the `POST` response
- the request eventually times out

After removing the blocking `POST` response read, the session proceeds normally: `OPTIONS`, `DESCRIBE`, auth challenge/retry, `SETUP`, `PLAY`, and RTP reception all succeed.

## Change

- keep the existing synchronous validation of the tunnel `GET` response
- stop synchronously calling `http.ReadResponse()` on the tunnel `POST` side during setup
- return the tunnel connection immediately after the `POST` headers are written

## Why this small fix

An asynchronous `POST`-response check was considered, but this PR intentionally keeps the change narrowly focused on removing the startup deadlock.

An async validation path would introduce additional lifecycle and error-handling complexity, including:

- a background goroutine blocked on the `POST` response
- coordination between normal shutdown and asynchronous error paths
- deciding how async `POST` failures should be surfaced to callers
- handling races between late `POST` responses, connection closure, and in-flight writes

For this fix, the simpler behavior is intentional: preserve the existing `GET`-side validation, avoid blocking tunnel startup on the `POST` response, and keep the patch small and easy to audit.

## Tradeoff

This no longer performs eager validation of the `POST` HTTP response during tunnel setup.

That is an acceptable tradeoff for this change because:

- the `GET` side is still validated synchronously
- many meaningful setup failures would already surface on the `GET` side
- the primary issue here is a real interoperability deadlock against deployed servers

The goal of this PR is to make tunnel startup non-blocking on the `POST` response and improve interoperability with real-world RTSP-over-HTTP servers.

## Tests

The existing HTTP tunnel client test still covers the normal case where the server replies immediately to both tunnel requests.

A focused regression test was added for the interoperability case where:

1. the server accepts the tunnel `GET` and returns `200 OK`
2. the server accepts the tunnel `POST`
3. the server does not send the `POST` response immediately
4. the client must still proceed to send tunneled RTSP `OPTIONS` / `DESCRIBE`

That regression fails with the old blocking behavior and passes with this patch.
