### PR TITLE
fix: avoid nil pointer panic in ServerStream.Close for reader without transport

### DIFF
--- a/server_stream.go
+++ b/server_stream.go
@@ -303,6 +303,10 @@ func (st *ServerStream) readerRemove(ss *ServerSession) {
 func (st *ServerStream) readerRemoveUnsafe(ss *ServerSession) {
 	delete(st.readers, ss)
 
+	if ss.setuppedTransport == nil {
+		return
+	}
+
 	if ss.setuppedTransport.Protocol == ProtocolUDPMulticast {
 		st.multicastReaderCount--
 		if st.multicastReaderCount == 0 {
@@ -345,6 +349,10 @@ func (st *ServerStream) readerSetInactive(ss *ServerSession) {
 }
 
 func (st *ServerStream) readerSetInactiveUnsafe(ss *ServerSession) {
+	if ss.setuppedTransport == nil {
+		return
+	}
+
 	if ss.setuppedTransport.Protocol == ProtocolUDPMulticast {
 		for medi := range ss.setuppedMedias {
 			streamMedia := st.medias[medi]

--- a/server_stream_test.go
+++ b/server_stream_test.go
@@ -1,0 +1,24 @@
+package gortsplib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// a reader can be in st.readers before SETUP has assigned setuppedTransport.
+func TestServerStreamCloseWithUnsetupReader(t *testing.T) {
+	stream := &ServerStream{
+		readers:              make(map[*ServerSession]struct{}),
+		activeUnicastReaders: make(map[*ServerSession]struct{}),
+	}
+
+	ss := &ServerSession{}
+	ss.ctx, ss.ctxCancel = context.WithCancel(context.Background())
+	stream.readers[ss] = struct{}{}
+
+	require.NotPanics(t, func() {
+		stream.Close()
+	})
+}


### PR DESCRIPTION
A reader session can be present in `ServerStream.readers` before SETUP has populated `setuppedTransport` (for instance when SETUP fails after `readerAdd`), and `Close()` then dereferences the nil transport in `readerSetInactiveUnsafe`/`readerRemoveUnsafe` and panics. This guards both helpers against a nil `setuppedTransport` and adds a regression test. Closes #1056