### PR TITLE
client: trigger TCP timeout only if nothing is received (#1002) (#968)

### DIFF
--- a/client.go
+++ b/client.go
@@ -570,7 +570,7 @@ type Client struct {
 	lastRange             *headers.Range
 	checkTimeoutTimer     *time.Timer
 	checkTimeoutInitial   bool
-	tcpLastFrameTime      atomic.Int64
+	tcpLastInboundTime    atomic.Int64
 	keepAlivePeriod       time.Duration
 	keepAliveTimer        *time.Timer
 	closeError            error
@@ -1076,7 +1076,6 @@ func (c *Client) startTransportRoutines() {
 
 		default: // TCP
 			c.checkTimeoutTimer = time.NewTimer(c.checkTimeoutPeriod)
-			c.tcpLastFrameTime.Store(c.timeNow().Unix())
 		}
 	}
 
@@ -1339,7 +1338,7 @@ func (c *Client) isInUDPTimeout() bool {
 
 func (c *Client) isInTCPTimeout() bool {
 	now := c.timeNow()
-	lft := time.Unix(c.tcpLastFrameTime.Load(), 0)
+	lft := time.Unix(c.tcpLastInboundTime.Load(), 0)
 	return now.Sub(lft) >= c.ReadTimeout
 }
 

--- a/client_media.go
+++ b/client_media.go
@@ -342,16 +342,12 @@ func (cm *clientMedia) readPacketRTPTCPPlay(payload []byte) bool {
 	cm.bytesReceived.Add(uint64(len(payload)))
 
 	now := cm.c.timeNow()
-	cm.c.tcpLastFrameTime.Store(now.Unix())
 
 	return cm.readPacketRTP(payload, now)
 }
 
 func (cm *clientMedia) readPacketRTCPTCPPlay(payload []byte) bool {
 	cm.bytesReceived.Add(uint64(len(payload)))
-
-	now := cm.c.timeNow()
-	cm.c.tcpLastFrameTime.Store(now.Unix())
 
 	if len(payload) > udpMaxPayloadSize {
 		cm.onPacketRTCPDecodeError(liberrors.ErrClientRTCPPacketTooBig{L: len(payload), Max: udpMaxPayloadSize})

--- a/client_reader.go
+++ b/client_reader.go
@@ -54,6 +54,9 @@ func (r *clientReader) runInner() error {
 			return err
 		}
 
+		now := r.c.timeNow()
+		r.c.tcpLastInboundTime.Store(now.Unix())
+
 		switch what := what.(type) {
 		case *base.Response:
 			select {


### PR DESCRIPTION
Previously, a data packet was required, now a keepalive response from the server is enough.