### PR TITLE
sdp: add non-standard 'meta' media type (BZBGEAR BG-VPTZ-10HSU3)

### DIFF
--- a/pkg/sdp/sdp.go
+++ b/pkg/sdp/sdp.go
@@ -454,6 +454,7 @@ func (s *SessionDescription) unmarshalMediaDescription(value string) error {
 		fields[0] != "application" &&
 		!strings.HasPrefix(fields[0], "application/") &&
 		fields[0] != "metadata" &&
+		fields[0] != "meta" &&
 		fields[0] != "text" {
 		return fmt.Errorf("%w `%v`", errSDPInvalidValue, fields[0])
 	}

--- a/pkg/sdp/sdp_test.go
+++ b/pkg/sdp/sdp_test.go
@@ -2611,43 +2611,6 @@ var cases = []struct {
 		},
 	},
 	{
-		"issue gortsplib/1068 (BZBGEAR BG-VPTZ-10HSU3)",
-		[]byte("m=meta 0 RTP/AVP 123\r\n" +
-			"b=AS:0\r\n" +
-			"a=rtpmap:123 META /0\r\n" +
-			"a=control:track=2\r\n"),
-		[]byte("v=0\r\n" +
-			"o= 0 0   \r\n" +
-			"s=\r\n" +
-			"m=meta 0 RTP/AVP 123\r\n" +
-			"b=AS:0\r\n" +
-			"a=rtpmap:123 META /0\r\n" +
-			"a=control:track=2\r\n"),
-		SessionDescription{
-			MediaDescriptions: []*psdp.MediaDescription{{
-				MediaName: psdp.MediaName{
-					Media:   "meta",
-					Protos:  []string{"RTP", "AVP"},
-					Formats: []string{"123"},
-				},
-				Bandwidth: []psdp.Bandwidth{{
-					Type:      "AS",
-					Bandwidth: 0,
-				}},
-				Attributes: []psdp.Attribute{
-					{
-						Key:   "rtpmap",
-						Value: "123 META /0",
-					},
-					{
-						Key:   "control",
-						Value: "track=2",
-					},
-				},
-			}},
-		},
-	},
-	{
 		"issue mediamtx/2762 (Altasec NVR)",
 		[]byte("v=0\r\n" +
 			"o=Channel1 3910280086 3910366486 IN IP4\r\n" +
@@ -3448,6 +3411,43 @@ var cases = []struct {
 					},
 				},
 			},
+		},
+	},
+	{
+		"issue gortsplib/1068 (BZBGEAR BG-VPTZ-10HSU3)",
+		[]byte("m=meta 0 RTP/AVP 123\r\n" +
+			"b=AS:0\r\n" +
+			"a=rtpmap:123 META /0\r\n" +
+			"a=control:track=2\r\n"),
+		[]byte("v=0\r\n" +
+			"o= 0 0   \r\n" +
+			"s=\r\n" +
+			"m=meta 0 RTP/AVP 123\r\n" +
+			"b=AS:0\r\n" +
+			"a=rtpmap:123 META /0\r\n" +
+			"a=control:track=2\r\n"),
+		SessionDescription{
+			MediaDescriptions: []*psdp.MediaDescription{{
+				MediaName: psdp.MediaName{
+					Media:   "meta",
+					Protos:  []string{"RTP", "AVP"},
+					Formats: []string{"123"},
+				},
+				Bandwidth: []psdp.Bandwidth{{
+					Type:      "AS",
+					Bandwidth: 0,
+				}},
+				Attributes: []psdp.Attribute{
+					{
+						Key:   "rtpmap",
+						Value: "123 META /0",
+					},
+					{
+						Key:   "control",
+						Value: "track=2",
+					},
+				},
+			}},
 		},
 	},
 }

--- a/pkg/sdp/sdp_test.go
+++ b/pkg/sdp/sdp_test.go
@@ -2611,7 +2611,7 @@ var cases = []struct {
 		},
 	},
 	{
-		"BZBGEAR BG-VPTZ-10HSU3",
+		"issue gortsplib/1068 (BZBGEAR BG-VPTZ-10HSU3)",
 		[]byte("m=meta 0 RTP/AVP 123\r\n" +
 			"b=AS:0\r\n" +
 			"a=rtpmap:123 META /0\r\n" +

--- a/pkg/sdp/sdp_test.go
+++ b/pkg/sdp/sdp_test.go
@@ -2611,6 +2611,43 @@ var cases = []struct {
 		},
 	},
 	{
+		"BZBGEAR BG-VPTZ-10HSU3",
+		[]byte("m=meta 0 RTP/AVP 123\r\n" +
+			"b=AS:0\r\n" +
+			"a=rtpmap:123 META /0\r\n" +
+			"a=control:track=2\r\n"),
+		[]byte("v=0\r\n" +
+			"o= 0 0   \r\n" +
+			"s=\r\n" +
+			"m=meta 0 RTP/AVP 123\r\n" +
+			"b=AS:0\r\n" +
+			"a=rtpmap:123 META /0\r\n" +
+			"a=control:track=2\r\n"),
+		SessionDescription{
+			MediaDescriptions: []*psdp.MediaDescription{{
+				MediaName: psdp.MediaName{
+					Media:   "meta",
+					Protos:  []string{"RTP", "AVP"},
+					Formats: []string{"123"},
+				},
+				Bandwidth: []psdp.Bandwidth{{
+					Type:      "AS",
+					Bandwidth: 0,
+				}},
+				Attributes: []psdp.Attribute{
+					{
+						Key:   "rtpmap",
+						Value: "123 META /0",
+					},
+					{
+						Key:   "control",
+						Value: "track=2",
+					},
+				},
+			}},
+		},
+	},
+	{
 		"issue mediamtx/2762 (Altasec NVR)",
 		[]byte("v=0\r\n" +
 			"o=Channel1 3910280086 3910366486 IN IP4\r\n" +


### PR DESCRIPTION
I am using a [BZBGEAR BG-VPTZ-10HSU3](https://bzbgear.com/product/bg-vptz-hsu3-ptz-full-hd-1080p-10x-20x-30x-hdmi-sdi-usb-3-0-live-streaming-camera) with MediaRTX.

The RTSP server on this camera serves SDP with `m=meta` which may be non-standard and currently gortsplib rejects it.

This adds "meta" as a valid media description, like https://github.com/bluenviron/gortsplib/issues/474

Edit: The OEM might be Shenzhen PUAS Industrial Co., Ltd. for example the [PUS-HD500BN](https://www.szpuas.com/en/product/61.html).