### PR TITLE
forbid H264 packetization mode zero

### DIFF
--- a/pkg/format/h264_test.go
+++ b/pkg/format/h264_test.go
@@ -45,7 +45,7 @@ func TestH264PTSEqualsDTS(t *testing.T) {
 }
 
 func TestH264DecEncoder(t *testing.T) {
-	format := &H264{}
+	format := &H264{PacketizationMode: 1}
 
 	enc, err := format.CreateEncoder()
 	require.NoError(t, err)

--- a/pkg/format/rtph264/decoder.go
+++ b/pkg/format/rtph264/decoder.go
@@ -93,8 +93,8 @@ type Decoder struct {
 
 // Init initializes the decoder.
 func (d *Decoder) Init() error {
-	if d.PacketizationMode >= 2 {
-		return fmt.Errorf("PacketizationMode >= 2 is not supported")
+	if d.PacketizationMode != 1 {
+		return fmt.Errorf("unsupported packetization mode: %d", d.PacketizationMode)
 	}
 	return nil
 }

--- a/pkg/format/rtph264/decoder_test.go
+++ b/pkg/format/rtph264/decoder_test.go
@@ -14,7 +14,7 @@ import (
 func TestDecode(t *testing.T) {
 	for _, ca := range cases {
 		t.Run(ca.name, func(t *testing.T) {
-			d := &Decoder{}
+			d := &Decoder{PacketizationMode: 1}
 			err := d.Init()
 			require.NoError(t, err)
 
@@ -363,7 +363,7 @@ var casesDecodeOnly = []struct {
 func TestDecodeOnly(t *testing.T) {
 	for _, ca := range casesDecodeOnly {
 		t.Run(ca.name, func(t *testing.T) {
-			d := &Decoder{}
+			d := &Decoder{PacketizationMode: 1}
 			err := d.Init()
 			require.NoError(t, err)
 
@@ -385,7 +385,7 @@ func TestDecodeOnly(t *testing.T) {
 }
 
 func TestDecodeErrorNALUSize(t *testing.T) {
-	d := &Decoder{}
+	d := &Decoder{PacketizationMode: 1}
 	err := d.Init()
 	require.NoError(t, err)
 
@@ -421,7 +421,7 @@ func TestDecodeErrorNALUSize(t *testing.T) {
 }
 
 func TestDecodeErrorNALUCount(t *testing.T) {
-	d := &Decoder{}
+	d := &Decoder{PacketizationMode: 1}
 	err := d.Init()
 	require.NoError(t, err)
 
@@ -443,7 +443,7 @@ func TestDecodeErrorNALUCount(t *testing.T) {
 }
 
 func TestDecodeErrorMissingPacket(t *testing.T) {
-	d := &Decoder{}
+	d := &Decoder{PacketizationMode: 1}
 	err := d.Init()
 	require.NoError(t, err)
 
@@ -547,7 +547,7 @@ func FuzzDecoder(f *testing.F) {
 			return
 		}
 
-		d := &Decoder{}
+		d := &Decoder{PacketizationMode: 1}
 		err = d.Init()
 		require.NoError(t, err)
 

--- a/pkg/format/rtph264/encoder.go
+++ b/pkg/format/rtph264/encoder.go
@@ -76,8 +76,8 @@ type Encoder struct {
 
 // Init initializes the encoder.
 func (e *Encoder) Init() error {
-	if e.PacketizationMode >= 2 {
-		return fmt.Errorf("PacketizationMode >= 2 is not supported")
+	if e.PacketizationMode != 1 {
+		return fmt.Errorf("unsupported packetization mode: %d", e.PacketizationMode)
 	}
 
 	if e.SSRC == nil {

--- a/pkg/format/rtph264/encoder_test.go
+++ b/pkg/format/rtph264/encoder_test.go
@@ -281,6 +281,7 @@ func TestEncode(t *testing.T) {
 	for _, ca := range cases {
 		t.Run(ca.name, func(t *testing.T) {
 			e := &Encoder{
+				PacketizationMode:     1,
 				PayloadType:           96,
 				SSRC:                  ptrOf(uint32(0x9dbb7812)),
 				InitialSequenceNumber: ptrOf(uint16(0x44ed)),
@@ -298,7 +299,8 @@ func TestEncode(t *testing.T) {
 
 func TestEncodeRandomInitialState(t *testing.T) {
 	e := &Encoder{
-		PayloadType: 96,
+		PacketizationMode: 1,
+		PayloadType:       96,
 	}
 	err := e.Init()
 	require.NoError(t, err)


### PR DESCRIPTION
Packetization mode zero requires allowing inefficient and brittle fragmented UDP packets, which we are not.