### PR TITLE
description: add optional Language field to Media

### DIFF
--- a/pkg/description/media.go
+++ b/pkg/description/media.go
@@ -88,6 +88,9 @@ type Media struct {
 	// Control attribute.
 	Control string
 
+	// Language (ISO 639) of the media (optional).
+	Language string
+
 	// Formats contained into the media.
 	Formats []format.Format
 }


### PR DESCRIPTION
Adds an optional `Language` field to `description.Media` holding an ISO 639 code.

I need this for mediamtx. When SRT/MPEG-TS comes in, mediacommon now reads the language code out of the PMT (bluenviron/mediacommon#331), but there's nowhere to keep it once we cross into gortsplib land, so it gets dropped before the HLS muxer can use it. Adding the field on `Media` is the smallest fix. See bluenviron/mediamtx#4826 for the end-to-end use case.

I haven't touched SDP marshal/unmarshal. The field is just an in-memory carrier for library users. If you'd rather see `a=lang:` wired up too, say so and I'll do it in the same PR.

Tested with:
- `go test ./pkg/...`
- `golangci-lint run ./pkg/...`
