### PR TITLE
allow FU-A and STAP-A packets with H264 packetization-mode 0 (bluenviron/mediamtx#5887)

### DIFF
--- a/pkg/format/rtph264/decoder.go
+++ b/pkg/format/rtph264/decoder.go
@@ -115,10 +115,6 @@ func (d *Decoder) decodeNALUs(pkt *rtp.Packet) ([][]byte, error) {
 
 	switch typ {
 	case h264.NALUTypeFUA:
-		if d.PacketizationMode == 0 {
-			return nil, fmt.Errorf("received FU-A packet in packetization mode 0")
-		}
-
 		if len(pkt.Payload) < 2 {
 			return nil, fmt.Errorf("invalid FU-A packet (invalid size)")
 		}
@@ -186,10 +182,6 @@ func (d *Decoder) decodeNALUs(pkt *rtp.Packet) ([][]byte, error) {
 		d.resetFragments()
 
 	case h264.NALUTypeSTAPA:
-		if d.PacketizationMode == 0 {
-			return nil, fmt.Errorf("received STAP-A packet in packetization mode 0")
-		}
-
 		d.resetFragments()
 
 		payload := pkt.Payload[1:]

--- a/pkg/format/rtph264/decoder_test.go
+++ b/pkg/format/rtph264/decoder_test.go
@@ -405,6 +405,61 @@ func TestDecodePacketizationMode0(t *testing.T) {
 	require.Equal(t, [][]byte{{0x65, 0x88, 0x84, 0x00, 0x33}}, au)
 }
 
+func TestDecodePacketizationMode0AllowsFUAAndSTAPA(t *testing.T) {
+	t.Run("FU-A", func(t *testing.T) {
+		d := &Decoder{PacketizationMode: 0}
+		err := d.Init()
+		require.NoError(t, err)
+
+		_, err = d.Decode(&rtp.Packet{
+			Header: rtp.Header{
+				Version:        2,
+				Marker:         false,
+				PayloadType:    96,
+				SequenceNumber: 17645,
+				Timestamp:      2289527317,
+				SSRC:           0x9dbb7812,
+			},
+			Payload: []byte{0x7c, 0x85, 0xaa, 0xbb},
+		})
+		require.ErrorIs(t, err, ErrMorePacketsNeeded)
+
+		au, err := d.Decode(&rtp.Packet{
+			Header: rtp.Header{
+				Version:        2,
+				Marker:         true,
+				PayloadType:    96,
+				SequenceNumber: 17646,
+				Timestamp:      2289527317,
+				SSRC:           0x9dbb7812,
+			},
+			Payload: []byte{0x7c, 0x45, 0xcc, 0xdd},
+		})
+		require.NoError(t, err)
+		require.Equal(t, [][]byte{{0x65, 0xaa, 0xbb, 0xcc, 0xdd}}, au)
+	})
+
+	t.Run("STAP-A", func(t *testing.T) {
+		d := &Decoder{PacketizationMode: 0}
+		err := d.Init()
+		require.NoError(t, err)
+
+		au, err := d.Decode(&rtp.Packet{
+			Header: rtp.Header{
+				Version:        2,
+				Marker:         true,
+				PayloadType:    96,
+				SequenceNumber: 17645,
+				Timestamp:      2289527317,
+				SSRC:           0x9dbb7812,
+			},
+			Payload: []byte{0x18, 0x00, 0x02, 0xaa, 0xbb, 0x00, 0x03, 0xcc, 0xdd, 0xee},
+		})
+		require.NoError(t, err)
+		require.Equal(t, [][]byte{{0xaa, 0xbb}, {0xcc, 0xdd, 0xee}}, au)
+	})
+}
+
 func TestDecodeErrorNALUSize(t *testing.T) {
 	d := &Decoder{PacketizationMode: 1}
 	err := d.Init()


### PR DESCRIPTION
Fixes bluenviron/mediamtx#5887