### PR TITLE
rtpsender: send the initial sender report without waiting a period

### DIFF
--- a/pkg/rtpsender/sender.go
+++ b/pkg/rtpsender/sender.go
@@ -35,8 +35,9 @@ type Sender struct {
 	reportedLost       uint64
 	octetCount         uint32
 
-	terminate chan struct{}
-	done      chan struct{}
+	terminate   chan struct{}
+	done        chan struct{}
+	firstPacket chan struct{}
 }
 
 // Initialize initializes a Sender.
@@ -47,6 +48,7 @@ func (rs *Sender) Initialize() {
 
 	rs.terminate = make(chan struct{})
 	rs.done = make(chan struct{})
+	rs.firstPacket = make(chan struct{})
 
 	go rs.run()
 }
@@ -63,8 +65,37 @@ func (rs *Sender) run() {
 	t := time.NewTicker(rs.Period)
 	defer t.Stop()
 
+	// RFC 6051, section 3.2: a sender SHOULD transmit an initial compound RTCP packet
+	// immediately on joining a unicast session, so a receiver can establish the
+	// RTP-to-wall-clock mapping without waiting for the first periodic report.
+	//
+	// Emitting only on the ticker delays that mapping by Period (10s by default), and
+	// longer still when no RTP packet has been sent by the first tick -- report()
+	// returns nil then, so the next opportunity is another Period away. Any receiver
+	// that derives absolute time from sender reports is blind for that whole window on
+	// every connection and every reconnect: mediamtx's useAbsoluteTimestamp drops the
+	// packets outright, and GStreamer's rtpjitterbuffer attaches no
+	// reference-timestamp-meta. See bluenviron/gortsplib#1052.
+	//
+	// The channel is read into a local: setting it to nil after it fires makes that
+	// select case block forever, so the initial report is sent exactly once, without
+	// racing ProcessPacket for ownership of the field.
+	firstPacket := rs.firstPacket
+
 	for {
 		select {
+		case <-firstPacket:
+			firstPacket = nil
+
+			report := rs.report()
+			if report != nil {
+				rs.WritePacketRTCP(report)
+			}
+
+			// Restart the period from the initial report, so a tick that was already
+			// nearly due doesn't send a second report immediately after it.
+			t.Reset(rs.Period)
+
 		case <-t.C:
 			report := rs.report()
 			if report != nil {
@@ -104,11 +135,20 @@ func (rs *Sender) ProcessPacket(pkt *rtp.Packet, ntp time.Time, ptsEqualsDTS boo
 	defer rs.mutex.Unlock()
 
 	if ptsEqualsDTS {
+		isFirst := !rs.firstRTPPacketSent
+
 		rs.firstRTPPacketSent = true
 		rs.lastRTP = pkt.Timestamp
 		rs.lastNTP = ntp
 		rs.lastSystem = rs.TimeNow()
 		rs.localSSRC = pkt.SSRC
+
+		// Wakes run() to emit the initial sender report now that report() has the data
+		// it needs. Closed under the mutex and only on the false->true transition, so
+		// it happens exactly once.
+		if isFirst {
+			close(rs.firstPacket)
+		}
 	}
 
 	rs.lastSequenceNumber = pkt.SequenceNumber

--- a/pkg/rtpsender/sender_test.go
+++ b/pkg/rtpsender/sender_test.go
@@ -55,6 +55,23 @@ func TestSender(t *testing.T) {
 	ts := time.Date(2008, 0o5, 20, 22, 15, 20, 0, time.UTC)
 	rs.ProcessPacket(&rtpPkt, ts, true)
 
+	// The initial sender report is emitted as soon as the first packet establishes a
+	// RTP-to-NTP mapping, rather than at the first tick (RFC 6051, section 3.2).
+	// Receiving it here also orders the rest of the test against it: the sender cannot
+	// observe any later packet or clock change until this hand-off completes.
+	pkt := <-pktGenerated
+	require.Equal(t, &rtcp.SenderReport{
+		SSRC: 0xba9da416,
+		NTPTime: func() uint64 {
+			d := time.Date(2008, 5, 20, 22, 15, 20, 0, time.UTC)
+			s := uint64(d.UnixNano()) + 2208988800*1000000000
+			return (s/1000000000)<<32 | (s % 1000000000)
+		}(),
+		RTPTime:     1287987768,
+		PacketCount: 1,
+		OctetCount:  2,
+	}, pkt)
+
 	setCurTime(time.Date(2008, 5, 20, 22, 16, 22, 0, time.UTC))
 	rtpPkt = rtp.Packet{
 		Header: rtp.Header{
@@ -86,7 +103,7 @@ func TestSender(t *testing.T) {
 
 	setCurTime(time.Date(2008, 5, 20, 22, 16, 24, 0, time.UTC))
 
-	pkt := <-pktGenerated
+	pkt = <-pktGenerated
 	require.Equal(t, &rtcp.SenderReport{
 		SSRC: 0xba9da416,
 		NTPTime: func() uint64 {
@@ -185,4 +202,47 @@ func TestSenderZeroClockRate(t *testing.T) {
 		LastNTP:            time.Date(2008, time.May, 20, 22, 15, 20, 0, time.UTC),
 		TotalSent:          1,
 	}, stats)
+}
+
+// TestSenderInitialReportBeatsPeriod pins the behaviour RFC 6051 section 3.2 asks for:
+// a receiver must be able to establish the RTP-to-wall-clock mapping without waiting a
+// whole report period. Emitting only on the ticker leaves anything that derives absolute
+// time from sender reports blind for Period on every connection -- with a 10s default,
+// that is 10s of un-timestampable media per connect and per reconnect.
+func TestSenderInitialReportBeatsPeriod(t *testing.T) {
+	pktGenerated := make(chan rtcp.Packet, 1)
+	now := time.Date(2008, 5, 20, 22, 16, 20, 0, time.UTC)
+
+	rs := &Sender{
+		ClockRate: 90000,
+		Period:    1 * time.Hour, // a tick must never be what delivers this report
+		TimeNow:   func() time.Time { return now },
+		WritePacketRTCP: func(pkt rtcp.Packet) {
+			pktGenerated <- pkt
+		},
+	}
+	rs.Initialize()
+	defer rs.Close()
+
+	rs.ProcessPacket(&rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			Marker:         true,
+			PayloadType:    96,
+			SequenceNumber: 946,
+			Timestamp:      1287987768,
+			SSRC:           0xba9da416,
+		},
+		Payload: []byte("\x00\x00"),
+	}, time.Date(2008, 5, 20, 22, 15, 20, 0, time.UTC), true)
+
+	select {
+	case pkt := <-pktGenerated:
+		sr, ok := pkt.(*rtcp.SenderReport)
+		require.True(t, ok)
+		require.Equal(t, uint32(0xba9da416), sr.SSRC)
+		require.NotZero(t, sr.NTPTime)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no sender report within 2s despite a packet having been sent")
+	}
 }


### PR DESCRIPTION
Reports were emitted only on the ticker, so the first one arrived Period after Initialize (10s by default) -- and later still when no RTP packet had been sent by that first tick, since report() returns nil until then and the next opportunity is another Period away.

RFC 6051 section 3.2 asks a sender to transmit an initial compound RTCP packet immediately on joining a unicast session, precisely so a receiver can establish the RTP-to-wall-clock mapping without that wait. Anything deriving absolute time from sender reports is blind until the first one arrives: mediamtx with useAbsoluteTimestamp drops the packets outright, and GStreamer's rtpjitterbuffer attaches no reference-timestamp-meta -- on every connection and every reconnect.

Emit the report as soon as the first RTP packet provides the mapping, then restart the period from there so a nearly-due tick doesn't immediately send a second one.

TestSender now receives that initial report explicitly. It previously relied on the reporting goroutine losing a race against the test's own ProcessPacket calls, which happened to hold but was never guaranteed.

Refs: https://github.com/bluenviron/gortsplib/issues/1052