### PR TITLE
make multicast errors on single interfaces non-fatal (bluenviron/mediamtx#5574)

### DIFF
--- a/internal/asyncprocessor/async_processor.go
+++ b/internal/asyncprocessor/async_processor.go
@@ -48,20 +48,20 @@ func (w *Processor) Start() {
 func (w *Processor) run() {
 	defer close(w.done)
 
-	err := w.runInner()
-	w.OnError(w.ctx, err)
+	w.runInner()
 }
 
-func (w *Processor) runInner() error {
+func (w *Processor) runInner() {
 	for {
 		tmp, ok := w.buffer.Pull()
 		if !ok {
-			return nil
+			return
 		}
 
 		err := tmp.(func() error)()
 		if err != nil {
-			return err
+			w.OnError(w.ctx, err)
+			return
 		}
 	}
 }

--- a/server_multicast_writer_format.go
+++ b/server_multicast_writer_format.go
@@ -48,7 +48,12 @@ func (smf *serverMulticastWriterFormat) writePacketRTPEncoded(
 	smf.rtpSender.ProcessPacket(pkt, ntp, ptsEqualsDTS)
 
 	ok := smf.smm.writer.Push(func() error {
-		return smf.smm.rtpl.write(payload, smf.smm.rtpAddr)
+		smf.smm.rtpl.write(payload, smf.smm.rtpAddr) //nolint:errcheck
+
+		// do not report write errors for two reasons:
+		// - errors make the async processor stop silently, and there's no error reporting mechanism
+		// - we're writing to several interfaces at once, and the error might be located on a single one
+		return nil
 	})
 	if !ok {
 		return liberrors.ErrServerWriteQueueFull{}

--- a/server_multicast_writer_media.go
+++ b/server_multicast_writer_media.go
@@ -62,7 +62,9 @@ func (smm *serverMulticastWriterMedia) initialize() error {
 
 	smm.writer = &asyncprocessor.Processor{
 		BufferSize: smm.writeQueueSize,
-		OnError:    func(_ context.Context, _ error) {},
+		OnError: func(_ context.Context, _ error) {
+			panic("should not happen")
+		},
 	}
 	smm.writer.Initialize()
 	smm.writer.Start()
@@ -113,7 +115,12 @@ func (smm *serverMulticastWriterMedia) writePacketRTCP(pkt rtcp.Packet) error {
 
 func (smm *serverMulticastWriterMedia) writePacketRTCPEncoded(payload []byte) error {
 	ok := smm.writer.Push(func() error {
-		return smm.rtcpl.write(payload, smm.rtcpAddr)
+		smm.rtcpl.write(payload, smm.rtcpAddr) //nolint:errcheck
+
+		// do not report write errors for two reasons:
+		// - errors make the async processor stop silently, and there's no error reporting mechanism
+		// - we're writing to several interfaces at once, and the error might be located on a single one
+		return nil
 	})
 	if !ok {
 		return liberrors.ErrServerWriteQueueFull{}


### PR DESCRIPTION
Fixes bluenviron/mediamtx#5574

When writing multicast packets to several interfaces at one, a write error to a single interface was fatal and prevented writing to the other ones. Fix this.