### PR TITLE
fix(auth): accept relative digest URI (abs_path)

### DIFF
--- a/pkg/auth/verify.go
+++ b/pkg/auth/verify.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strings"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
 	"github.com/bluenviron/gortsplib/v5/pkg/headers"
@@ -26,8 +27,15 @@ func sha256Hex(in string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func urlMatches(expected string, received string, isSetup bool) bool {
-	if received == expected {
+func urlMatches(expected *base.URL, received string, isSetup bool) bool {
+	// RFC 2617, section 3.2.2 allows the digest URI to be either an absolute URI
+	// or an abs_path. Some clients (e.g. Bosch BVMS) use the latter.
+	expectedStr := expected.String()
+	if strings.HasPrefix(received, "/") {
+		expectedStr = expected.RequestURI()
+	}
+
+	if received == expectedStr {
 		return true
 	}
 
@@ -35,7 +43,8 @@ func urlMatches(expected string, received string, isSetup bool) bool {
 	// - VLC uses the stream base URL (with trailing slash)
 	// - HappyTime NVR uses the stream URL (without trailing slash)
 	if isSetup {
-		if m := reControlAttribute.FindStringSubmatch(expected); m != nil && (received == m[1] || (received+"/") == m[1]) {
+		if m := reControlAttribute.FindStringSubmatch(expectedStr); m != nil &&
+			(received == m[1] || (received+"/") == m[1]) {
 			return true
 		}
 	}
@@ -92,7 +101,7 @@ func Verify(
 			return fmt.Errorf("authentication failed")
 		}
 
-		if !urlMatches(req.URL.String(), auth.URI, req.Method == base.Setup) {
+		if !urlMatches(req.URL, auth.URI, req.Method == base.Setup) {
 			return fmt.Errorf("wrong URL")
 		}
 

--- a/pkg/auth/verify.go
+++ b/pkg/auth/verify.go
@@ -29,13 +29,8 @@ func sha256Hex(in string) string {
 
 func urlMatches(expected *base.URL, received string, isSetup bool) bool {
 	// RFC 2617, section 3.2.2 allows the digest URI to be either an absolute URI
-	// or an abs_path. Some clients (e.g. Bosch BVMS) use the latter.
-	expectedStr := expected.String()
-	if strings.HasPrefix(received, "/") {
-		expectedStr = expected.RequestURI()
-	}
-
-	if received == expectedStr {
+	// or a relative path. Some clients (e.g. Bosch BVMS) use the latter.
+	if (strings.HasPrefix(received, "/") && received == expected.RequestURI()) || received == expected.String() {
 		return true
 	}
 
@@ -43,7 +38,7 @@ func urlMatches(expected *base.URL, received string, isSetup bool) bool {
 	// - VLC uses the stream base URL (with trailing slash)
 	// - HappyTime NVR uses the stream URL (without trailing slash)
 	if isSetup {
-		if m := reControlAttribute.FindStringSubmatch(expectedStr); m != nil &&
+		if m := reControlAttribute.FindStringSubmatch(expected.String()); m != nil &&
 			(received == m[1] || (received+"/") == m[1]) {
 			return true
 		}

--- a/pkg/auth/verify_test.go
+++ b/pkg/auth/verify_test.go
@@ -58,24 +58,10 @@ var casesVerify = []struct {
 		},
 	},
 	{
-		"digest relative uri",
+		"digest Bosch BVMS",
 		base.HeaderValue{
 			`Digest username="myuser", realm="myrealm", nonce="f49ac6dd0ba708d4becddc9692d1f2ce", ` +
 				`uri="/mypath?key=val/trackID=3", response="d78ea008e655a7218f0c7e53db6115a5"`,
-		},
-	},
-	{
-		"digest relative uri vlc",
-		base.HeaderValue{
-			`Digest username="myuser", realm="myrealm", nonce="f49ac6dd0ba708d4becddc9692d1f2ce", ` +
-				`uri="/mypath?key=val/", response="bd06a80ca4d1fc6a57242e72fe04f896"`,
-		},
-	},
-	{
-		"digest relative uri happytime",
-		base.HeaderValue{
-			`Digest username="myuser", realm="myrealm", nonce="f49ac6dd0ba708d4becddc9692d1f2ce", ` +
-				`uri="/mypath?key=val", response="4dde697b2c5268ce4f82cfab5d8bb4c2"`,
 		},
 	},
 }

--- a/pkg/auth/verify_test.go
+++ b/pkg/auth/verify_test.go
@@ -57,6 +57,27 @@ var casesVerify = []struct {
 				`uri="rtsp://myhost/mypath?key=val", response="c11a6e92b449f221dabf494a7a837ee3"`,
 		},
 	},
+	{
+		"digest relative uri",
+		base.HeaderValue{
+			`Digest username="myuser", realm="myrealm", nonce="f49ac6dd0ba708d4becddc9692d1f2ce", ` +
+				`uri="/mypath?key=val/trackID=3", response="d78ea008e655a7218f0c7e53db6115a5"`,
+		},
+	},
+	{
+		"digest relative uri vlc",
+		base.HeaderValue{
+			`Digest username="myuser", realm="myrealm", nonce="f49ac6dd0ba708d4becddc9692d1f2ce", ` +
+				`uri="/mypath?key=val/", response="bd06a80ca4d1fc6a57242e72fe04f896"`,
+		},
+	},
+	{
+		"digest relative uri happytime",
+		base.HeaderValue{
+			`Digest username="myuser", realm="myrealm", nonce="f49ac6dd0ba708d4becddc9692d1f2ce", ` +
+				`uri="/mypath?key=val", response="4dde697b2c5268ce4f82cfab5d8bb4c2"`,
+		},
+	},
 }
 
 func TestVerify(t *testing.T) {

--- a/pkg/base/url.go
+++ b/pkg/base/url.go
@@ -80,6 +80,11 @@ func (u *URL) CloneWithoutCredentials() *URL {
 	})
 }
 
+// RequestURI returns the path and query of the URL (abs_path).
+func (u *URL) RequestURI() string {
+	return (*url.URL)(u).RequestURI()
+}
+
 // Hostname returns u.Host, stripping any valid port number if present.
 //
 // If the result is enclosed in square brackets, as literal IPv6 addresses are,

--- a/pkg/base/url_test.go
+++ b/pkg/base/url_test.go
@@ -76,6 +76,44 @@ func TestURLParseErrors(t *testing.T) {
 	}
 }
 
+func TestURLRequestURI(t *testing.T) {
+	for _, ca := range []struct {
+		name string
+		enc  string
+		uri  string
+	}{
+		{
+			"base",
+			"rtsp://localhost:8554/test/stream",
+			"/test/stream",
+		},
+		{
+			"query",
+			"rtsp://localhost:8554/test/stream?key=val",
+			"/test/stream?key=val",
+		},
+		{
+			"credentials",
+			"rtsp://user:pass@localhost:8554/test/stream",
+			"/test/stream",
+		},
+		{
+			"escaped",
+			"rtsp://localhost:8554/test/prox%23ied",
+			"/test/prox%23ied",
+		},
+		{
+			"no path",
+			"rtsp://localhost:8554",
+			"/",
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			require.Equal(t, ca.uri, mustParseURL(ca.enc).RequestURI())
+		})
+	}
+}
+
 func TestURLClone(t *testing.T) {
 	u := mustParseURL("rtsp://localhost:8554/test/stream")
 	u2 := u.Clone()


### PR DESCRIPTION
Solves issue #1109.

The digest `URI` parameter can be an absolute or relative path. Some clients send the latter, which `urlMatches` incorrectly rejects, raising a "wrong URL". This PR adds a new validation path that accepts the URI without the prefix, which is redundant anyway.
The fix normalizes expected URL abs_path when the received URI uses that form. Two consequences worth noting:

* digest computation is unchanged: the response hash is already derived from
  the client-provided `auth.URI`, not from `req.URL`.
* `urlMatches` stays an exact comparison, so the check that binds the declared
  URI to the requested resource (preventing authentication for one path and a
  request for another) is preserved.

Tests cover the abs_path form for the plain and the new `base.URL.RequestURI` helper.