### PR TITLE
client: expose underlying net.Conn

### DIFF
--- a/client.go
+++ b/client.go
@@ -781,6 +781,15 @@ func (c *Client) Wait() error {
 	return c.closeError
 }
 
+// NetConn returns the underlying net.Conn of the control connection.
+// It returns nil if the connection is not open (before the first request or after Close).
+func (c *Client) NetConn() net.Conn {
+	c.propsMutex.RLock()
+	defer c.propsMutex.RUnlock()
+
+	return c.nconn
+}
+
 func (c *Client) run() {
 	defer close(c.done)
 
@@ -972,11 +981,19 @@ func (c *Client) doClose() {
 		c.nconn.Close()
 		c.reader.close()
 		c.reader = nil
+
+		c.propsMutex.Lock()
 		c.nconn = nil
+		c.propsMutex.Unlock()
+
 		c.conn = nil
 	} else if c.nconn != nil {
 		c.nconn.Close()
+
+		c.propsMutex.Lock()
 		c.nconn = nil
+		c.propsMutex.Unlock()
+
 		c.conn = nil
 	}
 
@@ -1221,7 +1238,10 @@ func (c *Client) connOpen(u *base.URL) error {
 		}
 	}
 
+	c.propsMutex.Lock()
 	c.nconn = nconn
+	c.propsMutex.Unlock()
+
 	bc := bytecounter.New(c.nconn, &c.bytesReceived, &c.bytesSent)
 	c.conn = conn.NewConn(bufio.NewReader(bc), bc)
 	c.reader = &clientReader{

--- a/client_test.go
+++ b/client_test.go
@@ -214,6 +214,90 @@ func TestClientSession(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClientNetConn(t *testing.T) {
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	releaseServer := make(chan struct{})
+	serverDone := make(chan struct{})
+	defer func() { <-serverDone }()
+
+	go func() {
+		defer close(serverDone)
+
+		nconn, err2 := l.Accept()
+		require.NoError(t, err2)
+		defer nconn.Close()
+		conn := conn.NewConn(bufio.NewReader(nconn), nconn)
+
+		req, err2 := conn.ReadRequest()
+		require.NoError(t, err2)
+		require.Equal(t, base.Options, req.Method)
+
+		err2 = conn.WriteResponse(&base.Response{
+			StatusCode: base.StatusOK,
+			Header: base.Header{
+				"Public": base.HeaderValue{strings.Join([]string{
+					string(base.Describe),
+				}, ", ")},
+			},
+		})
+		require.NoError(t, err2)
+
+		req, err2 = conn.ReadRequest()
+		require.NoError(t, err2)
+		require.Equal(t, base.Describe, req.Method)
+
+		medias := []*description.Media{testH264Media}
+
+		err2 = conn.WriteResponse(&base.Response{
+			StatusCode: base.StatusOK,
+			Header: base.Header{
+				"Content-Type": base.HeaderValue{"application/sdp"},
+			},
+			Body: mediasToSDP(medias),
+		})
+		require.NoError(t, err2)
+
+		<-releaseServer
+	}()
+
+	u, err := base.ParseURL("rtsp://" + l.Addr().String() + "/stream")
+	require.NoError(t, err)
+
+	c := Client{
+		Scheme: u.Scheme,
+		Host:   u.Host,
+	}
+
+	err = c.Start()
+	require.NoError(t, err)
+
+	// before any request, the control connection is not open
+	require.Nil(t, c.NetConn())
+
+	_, _, err = c.Describe(u)
+	require.NoError(t, err)
+
+	// after a request, NetConn returns the control connection
+	nc := c.NetConn()
+	require.NotNil(t, nc)
+
+	remoteAddr := nc.RemoteAddr().(*net.TCPAddr)
+	require.True(t, remoteAddr.IP.IsLoopback())
+	require.Equal(t, l.Addr().(*net.TCPAddr).Port, remoteAddr.Port)
+
+	localAddr := nc.LocalAddr().(*net.TCPAddr)
+	require.True(t, localAddr.IP.IsLoopback())
+
+	close(releaseServer)
+	c.Close()
+
+	// after Close, the control connection is gone
+	require.Nil(t, c.NetConn())
+}
+
 func TestClientCloseReleasesUDPSourcePorts(t *testing.T) {
 	l, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)


### PR DESCRIPTION
### What this does

Exposes the underlying `net.Conn` of the RTSP client through a new `Client.NetConn()` accessor.

### Why

This is needed by user to access the peer's `RemoteAddr()`. For example, https://github.com/bluenviron/mediamtx/issues/6058 requests exposing the remote address of forwarded connections so they can be correlated with network-level statistics.

### How

Added `Client.NetConn()` that returns the underlying control connection. The access is protected to safely handle the connection being replaced during its lifetime.

### Consistency

This follows the existing API style:

* `gortmplib.Client` already exposes `NetConn()`.
* The server side of this library already exposes the underlying connection through an accessor as well.

This keeps the client and server APIs consistent.