### PR TITLE
server: allow H264 packetization-mode=0 on TCP-only servers

### DIFF
--- a/server_session.go
+++ b/server_session.go
@@ -793,9 +793,12 @@ func (ss *ServerSession) handleRequestInner(sc *ServerConn, req *base.Request) (
 
 		for _, media := range desc.Medias {
 			if hasH264PacketizationMode0(media.Formats) {
-				return &base.Response{
-					StatusCode: base.StatusBadRequest,
-				}, liberrors.ErrServerH264PacketizationMode0{}
+				// reject only if UDP/multicast is available
+				if ss.s.UDPRTPAddress != "" || ss.s.MulticastIPRange != "" {
+					return &base.Response{
+						StatusCode: base.StatusBadRequest,
+					}, liberrors.ErrServerH264PacketizationMode0{}
+				}
 			}
 		}
 

--- a/server_stream_format.go
+++ b/server_stream_format.go
@@ -45,7 +45,11 @@ type serverStreamFormat struct {
 
 func (ssf *serverStreamFormat) initialize() error {
 	if h264Forma, ok := ssf.format.(*format.H264); ok && h264Forma.PacketizationMode == 0 {
-		return liberrors.ErrServerH264PacketizationMode0{}
+		// allow on TCP-only servers; isTransportSupported prevents UDP
+		srv := ssf.ssm.st.Server
+		if srv.UDPRTPAddress != "" || srv.MulticastIPRange != "" {
+			return liberrors.ErrServerH264PacketizationMode0{}
+		}
 	}
 
 	ssf.formatForDesc = cloneFormatShallow(ssf.format)

--- a/server_stream_h264_mode0_test.go
+++ b/server_stream_h264_mode0_test.go
@@ -1,0 +1,62 @@
+package gortsplib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
+	"github.com/bluenviron/gortsplib/v5/pkg/format"
+)
+
+func TestServerStreamH264PacketizationMode0TCPOK(t *testing.T) {
+	s := &Server{
+		RTSPAddress: "localhost:8554",
+	}
+	err := s.Start()
+	require.NoError(t, err)
+	defer s.Close()
+
+	forma := &format.H264{
+		PayloadTyp:        96,
+		PacketizationMode: 0,
+	}
+
+	stream := &ServerStream{
+		Server: s,
+		Desc: &description.Session{Medias: []*description.Media{{
+			Type:    description.MediaTypeVideo,
+			Formats: []format.Format{forma},
+		}}},
+	}
+	err = stream.Initialize()
+	require.NoError(t, err)
+	defer stream.Close()
+}
+
+func TestServerStreamH264PacketizationMode0UDPReject(t *testing.T) {
+	s := &Server{
+		RTSPAddress:    "localhost:8555",
+		UDPRTPAddress:  "127.0.0.1:8002",
+		UDPRTCPAddress: "127.0.0.1:8003",
+	}
+	err := s.Start()
+	require.NoError(t, err)
+	defer s.Close()
+
+	forma := &format.H264{
+		PayloadTyp:        96,
+		PacketizationMode: 0,
+	}
+
+	stream := &ServerStream{
+		Server: s,
+		Desc: &description.Session{Medias: []*description.Media{{
+			Type:    description.MediaTypeVideo,
+			Formats: []format.Format{forma},
+		}}},
+	}
+	err = stream.Initialize()
+	require.Error(t, err)
+	require.EqualError(t, err, "H264 packetization-mode=0 is not supported by the server")
+}


### PR DESCRIPTION
Safe on TCP-only servers since isTransportSupported() already prevents UDP connections.