### PR TITLE
Support SDES (RFC 4568) SRTP key exchange for RTSP/RTSPS sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ In RTSP, media streams are transmitted by using RTP packets, which are encoded i
 |[RFC8866, SDP: Session Description Protocol](https://datatracker.ietf.org/doc/html/rfc8866)|SDP|
 |[RFC4567, Key Management Extensions for Session Description Protocol (SDP) and Real Time Streaming Protocol (RTSP)](https://datatracker.ietf.org/doc/html/rfc4567)|secure variants|
 |[RFC3830, MIKEY: Multimedia Internet KEYing](https://datatracker.ietf.org/doc/html/rfc3830)|secure variants|
+|[RFC4568, SDP Security Descriptions for Media Streams](https://datatracker.ietf.org/doc/html/rfc4568)|secure variants|
 |[RTP Payload Format For AV1 (v1.0)](https://aomediacodec.github.io/av1-rtp-spec/)|payload formats / AV1|
 |[RFC9628, RTP Payload Format for VP9 Video](https://datatracker.ietf.org/doc/html/rfc9628)|payload formats / VP9|
 |[RFC7741, RTP Payload Format for VP8 Video](https://datatracker.ietf.org/doc/html/rfc7741)|payload formats / VP8|

--- a/client.go
+++ b/client.go
@@ -2106,8 +2106,38 @@ func (c *Client) doSetup(
 		return nil, fmt.Errorf("returned profile does not match requested profile")
 	}
 
-	if isSecure(th.Profile) {
-		if c.axisClientManagedKeys {
+	// Some servers (observed on UniFi Protect cameras) advertise SDES key
+	// material ("a=crypto") for a media while still labeling its "m=" line
+	// as plain (non-secure) AVP rather than SAVP, and consequently never
+	// negotiate a secure transport profile at all. Since inbound decryption
+	// is a purely client-side decision — the server sends SRTP-encrypted
+	// bytes over the wire regardless of which profile label was
+	// negotiated — key material being present at the SDP level is treated
+	// as sufficient reason to decrypt, independent of th.Profile.
+	//
+	// This only applies when playing (reading from a server): medi's
+	// KeyMgmtMikey/KeyMgmtSDES fields are always freshly parsed from that
+	// server's own DESCRIBE response in that case. When recording
+	// (c.state == clientStatePreRecord), medi is instead a caller-supplied,
+	// potentially reused Media — and prepareForAnnounce() sets
+	// KeyMgmtMikey on it as a side effect of describing our own outbound
+	// key, which says nothing about whether the *inbound* direction (e.g.
+	// backchannel) is actually secured. Fall back to th.Profile alone there.
+	inboundSecure := isSecure(th.Profile) ||
+		(c.state != clientStatePreRecord && (medi.KeyMgmtMikey != nil || medi.KeyMgmtSDES != nil))
+
+	if inboundSecure {
+		// extract key-mgmt from (in order of priority):
+		// - the Axis client-managed-keys fallback (only ever reachable together
+		//   with a genuinely negotiated secure profile, since it reuses the
+		//   outbound context built for that case)
+		// - response (MIKEY)
+		// - media SDP attributes (MIKEY)
+		// - media SDP attributes (SDES, RFC 4568 "a=crypto" — e.g. UniFi
+		//   Protect cameras)
+		// - session SDP attributes (MIKEY)
+		switch {
+		case c.axisClientManagedKeys && isSecure(th.Profile):
 			srtpInCtx = &wrappedSRTPContext{
 				key: srtpOutCtx.key,
 				mki: srtpOutCtx.mki,
@@ -2116,54 +2146,46 @@ func (c *Client) doSetup(
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			// extract key-mgmt from (in order of priority):
-			// - response (MIKEY)
-			// - media SDP attributes (MIKEY)
-			// - media SDP attributes (SDES, RFC 4568 "a=crypto" — e.g. UniFi
-			//   Protect cameras)
-			// - session SDP attributes (MIKEY)
-			switch {
-			case res.Header["KeyMgmt"] != nil:
-				var keyMgmt headers.KeyMgmt
-				err = keyMgmt.Unmarshal(res.Header["KeyMgmt"])
-				if err != nil {
-					return nil, err
-				}
 
-				srtpInCtx, err = mikeyToContext(keyMgmt.MikeyMessage)
-				if err != nil {
-					return nil, err
-				}
-
-			case medi.KeyMgmtMikey != nil:
-				srtpInCtx, err = mikeyToContext(medi.KeyMgmtMikey)
-				if err != nil {
-					return nil, err
-				}
-
-			case medi.KeyMgmtSDES != nil:
-				srtpInCtx, err = sdesToContext(medi.KeyMgmtSDES)
-				if err != nil {
-					return nil, err
-				}
-
-			case c.lastDescribeDesc.KeyMgmtMikey != nil:
-				srtpInCtx, err = mikeyToContext(c.lastDescribeDesc.KeyMgmtMikey)
-				if err != nil {
-					return nil, err
-				}
-
-			default:
-				return nil, fmt.Errorf("server did not provide key-mgmt data in any supported way")
+		case res.Header["KeyMgmt"] != nil:
+			var keyMgmt headers.KeyMgmt
+			err = keyMgmt.Unmarshal(res.Header["KeyMgmt"])
+			if err != nil {
+				return nil, err
 			}
+
+			srtpInCtx, err = mikeyToContext(keyMgmt.MikeyMessage)
+			if err != nil {
+				return nil, err
+			}
+
+		case medi.KeyMgmtMikey != nil:
+			srtpInCtx, err = mikeyToContext(medi.KeyMgmtMikey)
+			if err != nil {
+				return nil, err
+			}
+
+		case medi.KeyMgmtSDES != nil:
+			srtpInCtx, err = sdesToContext(medi.KeyMgmtSDES)
+			if err != nil {
+				return nil, err
+			}
+
+		case c.lastDescribeDesc.KeyMgmtMikey != nil:
+			srtpInCtx, err = mikeyToContext(c.lastDescribeDesc.KeyMgmtMikey)
+			if err != nil {
+				return nil, err
+			}
+
+		default:
+			return nil, fmt.Errorf("server did not provide key-mgmt data in any supported way")
 		}
 	}
 
 	cm := &clientMedia{
 		c:               c,
 		media:           medi,
-		secure:          isSecure(th.Profile),
+		secure:          inboundSecure,
 		udpRTPListener:  udpRTPListener,
 		udpRTCPListener: udpRTCPListener,
 		tcpChannel:      tcpChannel,

--- a/client.go
+++ b/client.go
@@ -2117,12 +2117,12 @@ func (c *Client) doSetup(
 				return nil, err
 			}
 		} else {
-			var mikeyMsg *mikey.Message
-
 			// extract key-mgmt from (in order of priority):
-			// - response
-			// - media SDP attributes
-			// - session SDP attributes
+			// - response (MIKEY)
+			// - media SDP attributes (MIKEY)
+			// - media SDP attributes (SDES, RFC 4568 "a=crypto" — e.g. UniFi
+			//   Protect cameras)
+			// - session SDP attributes (MIKEY)
 			switch {
 			case res.Header["KeyMgmt"] != nil:
 				var keyMgmt headers.KeyMgmt
@@ -2130,21 +2130,32 @@ func (c *Client) doSetup(
 				if err != nil {
 					return nil, err
 				}
-				mikeyMsg = keyMgmt.MikeyMessage
+
+				srtpInCtx, err = mikeyToContext(keyMgmt.MikeyMessage)
+				if err != nil {
+					return nil, err
+				}
 
 			case medi.KeyMgmtMikey != nil:
-				mikeyMsg = medi.KeyMgmtMikey
+				srtpInCtx, err = mikeyToContext(medi.KeyMgmtMikey)
+				if err != nil {
+					return nil, err
+				}
+
+			case medi.KeyMgmtSDES != nil:
+				srtpInCtx, err = sdesToContext(medi.KeyMgmtSDES)
+				if err != nil {
+					return nil, err
+				}
 
 			case c.lastDescribeDesc.KeyMgmtMikey != nil:
-				mikeyMsg = c.lastDescribeDesc.KeyMgmtMikey
+				srtpInCtx, err = mikeyToContext(c.lastDescribeDesc.KeyMgmtMikey)
+				if err != nil {
+					return nil, err
+				}
 
 			default:
 				return nil, fmt.Errorf("server did not provide key-mgmt data in any supported way")
-			}
-
-			srtpInCtx, err = mikeyToContext(mikeyMsg)
-			if err != nil {
-				return nil, err
 			}
 		}
 	}

--- a/client_play_test.go
+++ b/client_play_test.go
@@ -913,6 +913,180 @@ func TestClientPlaySRTPVariants(t *testing.T) {
 	}
 }
 
+// TestClientPlaySDESVariants mirrors TestClientPlaySRTPVariants above, but
+// for SDES (RFC 4568) key exchange instead of MIKEY — the "a=crypto" SDP
+// attribute used by e.g. UniFi Protect cameras' "?enableSrtp" RTSPS streams.
+// Unlike MIKEY, SDES has no equivalent of a session-level attribute or a
+// SETUP-response-header variant, so there's only the one scenario to cover.
+func TestClientPlaySDESVariants(t *testing.T) {
+	cert, err := tls.X509KeyPair(serverCert, serverKey)
+	require.NoError(t, err)
+
+	l, err := tls.Listen("tcp", "127.0.0.1:8554", &tls.Config{Certificates: []tls.Certificate{cert}})
+	require.NoError(t, err)
+	defer l.Close()
+
+	serverDone := make(chan struct{})
+	defer func() { <-serverDone }()
+
+	go func() {
+		defer close(serverDone)
+
+		nconn, err2 := l.Accept()
+		require.NoError(t, err2)
+		defer nconn.Close()
+		conn := conn.NewConn(bufio.NewReader(nconn), nconn)
+
+		req, err2 := conn.ReadRequest()
+		require.NoError(t, err2)
+		require.Equal(t, base.Options, req.Method)
+
+		err2 = conn.WriteResponse(&base.Response{
+			StatusCode: base.StatusOK,
+			Header: base.Header{
+				"Public": base.HeaderValue{strings.Join([]string{
+					string(base.Describe),
+					string(base.Setup),
+					string(base.Play),
+				}, ", ")},
+			},
+		})
+		require.NoError(t, err2)
+
+		req, err2 = conn.ReadRequest()
+		require.NoError(t, err2)
+		require.Equal(t, base.Describe, req.Method)
+
+		outKey := make([]byte, srtpKeyLength)
+		_, err2 = rand.Read(outKey)
+		require.NoError(t, err2)
+
+		srtpOutCtx := &wrappedSRTPContext{
+			key:   outKey,
+			ssrcs: []uint32{845234432},
+		}
+		err2 = srtpOutCtx.initialize()
+		require.NoError(t, err2)
+
+		sdp := "v=0\n" +
+			"o=actionmovie 2891092738 2891092738 IN IP4 movie.example.com\n" +
+			"s=Action Movie\n" +
+			"t=0 0\n" +
+			"c=IN IP4 movie.example.com\n" +
+			"m=video 0 RTP/SAVP 96\n" +
+			"a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:" + base64.StdEncoding.EncodeToString(outKey) + "\n" +
+			"a=rtpmap:96 H264/90000\n" +
+			"a=fmtp:96 packetization-mode=1\n" +
+			"a=control:trackID=0\n"
+
+		err2 = conn.WriteResponse(&base.Response{
+			StatusCode: base.StatusOK,
+			Header: base.Header{
+				"Content-Type": base.HeaderValue{"application/sdp"},
+				"Content-Base": base.HeaderValue{"rtsps://127.0.0.1:8554/stream/"},
+			},
+			Body: []byte(sdp),
+		})
+		require.NoError(t, err2)
+
+		req, err2 = conn.ReadRequest()
+		require.NoError(t, err2)
+		require.Equal(t, base.Setup, req.Method)
+
+		var inTH headers.Transport
+		err2 = inTH.Unmarshal(req.Header["Transport"])
+		require.NoError(t, err2)
+
+		require.Equal(t, (*headers.TransportMode)(nil), inTH.Mode)
+
+		th := headers.Transport{
+			Profile: headers.TransportProfileSAVP,
+		}
+
+		th.Delivery = new(headers.TransportDeliveryUnicast)
+		th.Protocol = headers.TransportProtocolUDP
+		th.ClientPorts = inTH.ClientPorts
+		th.ServerPorts = &[2]int{34556, 34557}
+
+		l1, err2 := net.ListenPacket(
+			"udp", net.JoinHostPort("127.0.0.1", strconv.FormatInt(int64(th.ServerPorts[0]), 10)))
+		require.NoError(t, err2)
+		defer l1.Close()
+
+		err2 = conn.WriteResponse(&base.Response{
+			StatusCode: base.StatusOK,
+			Header: base.Header{
+				"Transport": th.Marshal(),
+			},
+		})
+		require.NoError(t, err2)
+
+		req, err2 = conn.ReadRequest()
+		require.NoError(t, err2)
+		require.Equal(t, base.Play, req.Method)
+
+		err2 = conn.WriteResponse(&base.Response{
+			StatusCode: base.StatusOK,
+		})
+		require.NoError(t, err2)
+
+		buf := testRTPPacketMarshaled
+
+		encr := make([]byte, 2000)
+		encr, err2 = srtpOutCtx.encryptRTP(encr, buf, nil)
+		require.NoError(t, err2)
+		buf = encr
+
+		_, err2 = l1.WriteTo(buf, &net.UDPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: th.ClientPorts[0],
+		})
+		require.NoError(t, err2)
+
+		req, err2 = conn.ReadRequest()
+		require.NoError(t, err2)
+		require.Equal(t, base.Teardown, req.Method)
+	}()
+
+	u, err := base.ParseURL("rtsps://127.0.0.1:8554/stream")
+	require.NoError(t, err)
+
+	c := Client{
+		Scheme:    u.Scheme,
+		Host:      u.Host,
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	err = c.Start()
+	require.NoError(t, err)
+	defer c.Close()
+
+	sd, _, err := c.Describe(u)
+	require.NoError(t, err)
+
+	err = c.SetupAll(sd.BaseURL, sd.Medias)
+	require.NoError(t, err)
+
+	packetRecv := make(chan struct{})
+
+	c.OnPacketRTPAny(func(_ *description.Media, _ format.Format, pkt *rtp.Packet) {
+		require.Equal(t, &rtp.Packet{
+			Header: rtp.Header{
+				Version:     2,
+				PayloadType: 96,
+				SSRC:        pkt.SSRC,
+			},
+			Payload: testRTPPacket.Payload,
+		}, pkt)
+		close(packetRecv)
+	})
+
+	_, err = c.Play(nil)
+	require.NoError(t, err)
+
+	<-packetRecv
+}
+
 func TestClientPlayAxisClientManagedKeys(t *testing.T) {
 	cert, err := tls.X509KeyPair(serverCert, serverKey)
 	require.NoError(t, err)

--- a/pkg/description/media.go
+++ b/pkg/description/media.go
@@ -85,6 +85,9 @@ type Media struct {
 	// key-mgmt attribute.
 	KeyMgmtMikey *mikey.Message
 
+	// crypto attribute (SDES, RFC 4568).
+	KeyMgmtSDES *KeyMgmtSDES
+
 	// Control attribute.
 	Control string
 
@@ -121,6 +124,14 @@ func (m *Media) Unmarshal(md *sdp.MediaDescription) error {
 
 		m.KeyMgmtMikey = &mikey.Message{}
 		err = m.KeyMgmtMikey.Unmarshal(enc2)
+		if err != nil {
+			return err
+		}
+	}
+
+	if enc := getAttribute(md.Attributes, "crypto"); enc != "" {
+		var err error
+		m.KeyMgmtSDES, err = unmarshalSDESCrypto(enc)
 		if err != nil {
 			return err
 		}

--- a/pkg/description/media.go
+++ b/pkg/description/media.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
 	"github.com/bluenviron/gortsplib/v5/pkg/headers"
 	"github.com/bluenviron/gortsplib/v5/pkg/mikey"
+	"github.com/bluenviron/gortsplib/v5/pkg/sdes"
 )
 
 func getAttribute(attributes []sdp.Attribute, key string) string {
@@ -86,7 +87,7 @@ type Media struct {
 	KeyMgmtMikey *mikey.Message
 
 	// crypto attribute (SDES, RFC 4568).
-	KeyMgmtSDES *KeyMgmtSDES
+	KeyMgmtSDES *sdes.SDES
 
 	// Control attribute.
 	Control string
@@ -130,8 +131,8 @@ func (m *Media) Unmarshal(md *sdp.MediaDescription) error {
 	}
 
 	if enc := getAttribute(md.Attributes, "crypto"); enc != "" {
-		var err error
-		m.KeyMgmtSDES, err = unmarshalSDESCrypto(enc)
+		m.KeyMgmtSDES = &sdes.SDES{}
+		err := m.KeyMgmtSDES.Unmarshal(enc)
 		if err != nil {
 			return err
 		}

--- a/pkg/description/media_test.go
+++ b/pkg/description/media_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
 	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/bluenviron/gortsplib/v5/pkg/format"
+	"github.com/bluenviron/gortsplib/v5/pkg/sdes"
 	"github.com/bluenviron/gortsplib/v5/pkg/sdpunmarshaler"
 )
 
@@ -186,57 +187,12 @@ func TestMediaKeyMgmtSDES(t *testing.T) {
 	err = media.Unmarshal(sd.MediaDescriptions[0])
 	require.NoError(t, err)
 
-	require.Equal(t, &description.KeyMgmtSDES{
+	require.Equal(t, &sdes.SDES{
 		Tag:   1,
 		Suite: "AES_CM_128_HMAC_SHA1_80",
 		Key:   expectedKey,
 	}, media.KeyMgmtSDES)
 	require.Nil(t, media.KeyMgmtMikey)
-}
-
-func TestMediaKeyMgmtSDESErrors(t *testing.T) {
-	for _, ca := range []struct {
-		name string
-		sdp  []byte
-		err  string
-	}{
-		{
-			"missing fields",
-			[]byte("v=0\r\n" +
-				"s= \r\n" +
-				"m=video 0 RTP/SAVP 96\r\n" +
-				"a=crypto:1 AES_CM_128_HMAC_SHA1_80\r\n" +
-				"a=rtpmap:96 H264/90000\r\n"),
-			"invalid crypto attribute: 1 AES_CM_128_HMAC_SHA1_80",
-		},
-		{
-			"non-inline key method",
-			[]byte("v=0\r\n" +
-				"s= \r\n" +
-				"m=video 0 RTP/SAVP 96\r\n" +
-				"a=crypto:1 AES_CM_128_HMAC_SHA1_80 mikey:AQAFgM0=\r\n" +
-				"a=rtpmap:96 H264/90000\r\n"),
-			"unsupported crypto key method: mikey:AQAFgM0=",
-		},
-		{
-			"invalid base64",
-			[]byte("v=0\r\n" +
-				"s= \r\n" +
-				"m=video 0 RTP/SAVP 96\r\n" +
-				"a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:not-valid-base64!!\r\n" +
-				"a=rtpmap:96 H264/90000\r\n"),
-			"invalid crypto inline key: illegal base64 data at input byte 3",
-		},
-	} {
-		t.Run(ca.name, func(t *testing.T) {
-			sd, err := sdpunmarshaler.Unmarshal(ca.sdp)
-			require.NoError(t, err)
-
-			var media description.Media
-			err = media.Unmarshal(sd.MediaDescriptions[0])
-			require.EqualError(t, err, ca.err)
-		})
-	}
 }
 
 func TestMediaURLError(t *testing.T) {

--- a/pkg/description/media_test.go
+++ b/pkg/description/media_test.go
@@ -1,6 +1,7 @@
 package description_test
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -161,6 +162,79 @@ func TestMediaURL(t *testing.T) {
 			ur, err := media.URL(ca.baseURL)
 			require.NoError(t, err)
 			require.Equal(t, ca.ur, ur)
+		})
+	}
+}
+
+func TestMediaKeyMgmtSDES(t *testing.T) {
+	// this exact inline key was captured from a real UniFi Protect camera's
+	// RTSPS ("?enableSrtp") DESCRIBE response.
+	const inlineKey = "5yQlV6XBpXYqEhsRoCs2OH+GujtAjltr3K6GPpyY"
+
+	expectedKey, err := base64.StdEncoding.DecodeString(inlineKey)
+	require.NoError(t, err)
+	require.Len(t, expectedKey, 30) // 16-byte master key + 14-byte master salt
+
+	sd, err := sdpunmarshaler.Unmarshal([]byte("v=0\r\n" +
+		"s= \r\n" +
+		"m=video 0 RTP/SAVP 96\r\n" +
+		"a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:" + inlineKey + "\r\n" +
+		"a=rtpmap:96 H264/90000\r\n"))
+	require.NoError(t, err)
+
+	var media description.Media
+	err = media.Unmarshal(sd.MediaDescriptions[0])
+	require.NoError(t, err)
+
+	require.Equal(t, &description.KeyMgmtSDES{
+		Tag:   1,
+		Suite: "AES_CM_128_HMAC_SHA1_80",
+		Key:   expectedKey,
+	}, media.KeyMgmtSDES)
+	require.Nil(t, media.KeyMgmtMikey)
+}
+
+func TestMediaKeyMgmtSDESErrors(t *testing.T) {
+	for _, ca := range []struct {
+		name string
+		sdp  []byte
+		err  string
+	}{
+		{
+			"missing fields",
+			[]byte("v=0\r\n" +
+				"s= \r\n" +
+				"m=video 0 RTP/SAVP 96\r\n" +
+				"a=crypto:1 AES_CM_128_HMAC_SHA1_80\r\n" +
+				"a=rtpmap:96 H264/90000\r\n"),
+			"invalid crypto attribute: 1 AES_CM_128_HMAC_SHA1_80",
+		},
+		{
+			"non-inline key method",
+			[]byte("v=0\r\n" +
+				"s= \r\n" +
+				"m=video 0 RTP/SAVP 96\r\n" +
+				"a=crypto:1 AES_CM_128_HMAC_SHA1_80 mikey:AQAFgM0=\r\n" +
+				"a=rtpmap:96 H264/90000\r\n"),
+			"unsupported crypto key method: mikey:AQAFgM0=",
+		},
+		{
+			"invalid base64",
+			[]byte("v=0\r\n" +
+				"s= \r\n" +
+				"m=video 0 RTP/SAVP 96\r\n" +
+				"a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:not-valid-base64!!\r\n" +
+				"a=rtpmap:96 H264/90000\r\n"),
+			"invalid crypto inline key: illegal base64 data at input byte 3",
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			sd, err := sdpunmarshaler.Unmarshal(ca.sdp)
+			require.NoError(t, err)
+
+			var media description.Media
+			err = media.Unmarshal(sd.MediaDescriptions[0])
+			require.EqualError(t, err, ca.err)
 		})
 	}
 }

--- a/pkg/description/sdes.go
+++ b/pkg/description/sdes.go
@@ -1,0 +1,82 @@
+package description
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// KeyMgmtSDES holds a parsed SDES (RFC 4568) "a=crypto" media attribute.
+//
+// This is a separate, independent key-exchange mechanism from MIKEY
+// (RFC 3830, see KeyMgmtMikey): SDES embeds the key material directly,
+// inline, in the SDP itself, rather than negotiating it via a MIKEY
+// message. It's what UniFi Protect cameras use for their "?enableSrtp"
+// RTSPS streams.
+type KeyMgmtSDES struct {
+	// Tag is the crypto suite tag from the SDP line (used to correlate a
+	// crypto line with a SETUP response in more elaborate negotiations;
+	// not security-relevant on its own).
+	Tag int
+
+	// Suite is the crypto suite name, e.g. "AES_CM_128_HMAC_SHA1_80".
+	Suite string
+
+	// Key is the raw, still-encoded-for-policy master key + master salt,
+	// decoded from the "inline" key parameter. Its expected length and
+	// interpretation depend on Suite (see sdesToContext).
+	Key []byte
+}
+
+// unmarshalSDESCrypto parses the value of an SDP "a=crypto" attribute, e.g.:
+//
+//	1 AES_CM_128_HMAC_SHA1_80 inline:5yQlV6XBpXYqEhsRoCs2OH+GujtAjltr3K6GPpyY
+//
+// Per RFC 4568, the general form is:
+//
+//	<tag> <crypto-suite> <key-params> [<session-params>]
+//
+// where <key-params> for inline keys is:
+//
+//	inline:<base64 key||salt>[|<lifetime>][|<mki>:<length>]
+//
+// This only extracts the tag, suite name, and decoded key material — it
+// deliberately does not validate the suite or key length here, matching how
+// the "key-mgmt" (MIKEY) attribute is handled just above: structural
+// decoding happens during SDP unmarshal, and policy/suite validation
+// happens later, when the key is turned into a wrappedSRTPContext.
+func unmarshalSDESCrypto(v string) (*KeyMgmtSDES, error) {
+	fields := strings.Fields(v)
+	if len(fields) < 3 {
+		return nil, fmt.Errorf("invalid crypto attribute: %v", v)
+	}
+
+	tag, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return nil, fmt.Errorf("invalid crypto tag: %v", fields[0])
+	}
+
+	suite := fields[1]
+
+	const inlinePrefix = "inline:"
+	if !strings.HasPrefix(fields[2], inlinePrefix) {
+		return nil, fmt.Errorf("unsupported crypto key method: %v", fields[2])
+	}
+
+	// the key parameter is <base64>[|<lifetime>][|<mki>:<length>];
+	// only the base64 key material is needed to decrypt.
+	rawKey := strings.TrimPrefix(fields[2], inlinePrefix)
+	rawKey, _, _ = strings.Cut(rawKey, "|")
+
+	key, err := base64.StdEncoding.DecodeString(rawKey)
+	if err != nil {
+		return nil, fmt.Errorf("invalid crypto inline key: %w", err)
+	}
+
+	return &KeyMgmtSDES{
+		Tag:   tag,
+		Suite: suite,
+		Key:   key,
+	}, nil
+}

--- a/pkg/sdes/sdes.go
+++ b/pkg/sdes/sdes.go
@@ -1,4 +1,5 @@
-package description
+// Package sdes contains a SDES (RFC 4568) key-exchange decoder.
+package sdes
 
 import (
 	"encoding/base64"
@@ -7,14 +8,14 @@ import (
 	"strings"
 )
 
-// KeyMgmtSDES holds a parsed SDES (RFC 4568) "a=crypto" media attribute.
+// SDES holds a parsed SDES (RFC 4568) "a=crypto" media attribute.
 //
 // This is a separate, independent key-exchange mechanism from MIKEY
-// (RFC 3830, see KeyMgmtMikey): SDES embeds the key material directly,
+// (RFC 3830, see the mikey package): SDES embeds the key material directly,
 // inline, in the SDP itself, rather than negotiating it via a MIKEY
 // message. It's what UniFi Protect cameras use for their "?enableSrtp"
 // RTSPS streams.
-type KeyMgmtSDES struct {
+type SDES struct {
 	// Tag is the crypto suite tag from the SDP line (used to correlate a
 	// crypto line with a SETUP response in more elaborate negotiations;
 	// not security-relevant on its own).
@@ -25,11 +26,11 @@ type KeyMgmtSDES struct {
 
 	// Key is the raw, still-encoded-for-policy master key + master salt,
 	// decoded from the "inline" key parameter. Its expected length and
-	// interpretation depend on Suite (see sdesToContext).
+	// interpretation depend on Suite.
 	Key []byte
 }
 
-// unmarshalSDESCrypto parses the value of an SDP "a=crypto" attribute, e.g.:
+// Unmarshal decodes the value of an SDP "a=crypto" attribute, e.g.:
 //
 //	1 AES_CM_128_HMAC_SHA1_80 inline:5yQlV6XBpXYqEhsRoCs2OH+GujtAjltr3K6GPpyY
 //
@@ -43,25 +44,25 @@ type KeyMgmtSDES struct {
 //
 // This only extracts the tag, suite name, and decoded key material — it
 // deliberately does not validate the suite or key length here, matching how
-// the "key-mgmt" (MIKEY) attribute is handled just above: structural
-// decoding happens during SDP unmarshal, and policy/suite validation
-// happens later, when the key is turned into a wrappedSRTPContext.
-func unmarshalSDESCrypto(v string) (*KeyMgmtSDES, error) {
+// the "key-mgmt" (MIKEY) attribute is handled: structural decoding happens
+// during SDP unmarshal, and policy/suite validation happens later, when the
+// key is turned into a SRTP context.
+func (s *SDES) Unmarshal(v string) error {
 	fields := strings.Fields(v)
 	if len(fields) < 3 {
-		return nil, fmt.Errorf("invalid crypto attribute: %v", v)
+		return fmt.Errorf("invalid crypto attribute: %v", v)
 	}
 
 	tag, err := strconv.Atoi(fields[0])
 	if err != nil {
-		return nil, fmt.Errorf("invalid crypto tag: %v", fields[0])
+		return fmt.Errorf("invalid crypto tag: %v", fields[0])
 	}
 
 	suite := fields[1]
 
 	const inlinePrefix = "inline:"
 	if !strings.HasPrefix(fields[2], inlinePrefix) {
-		return nil, fmt.Errorf("unsupported crypto key method: %v", fields[2])
+		return fmt.Errorf("unsupported crypto key method: %v", fields[2])
 	}
 
 	// the key parameter is <base64>[|<lifetime>][|<mki>:<length>];
@@ -71,12 +72,12 @@ func unmarshalSDESCrypto(v string) (*KeyMgmtSDES, error) {
 
 	key, err := base64.StdEncoding.DecodeString(rawKey)
 	if err != nil {
-		return nil, fmt.Errorf("invalid crypto inline key: %w", err)
+		return fmt.Errorf("invalid crypto inline key: %w", err)
 	}
 
-	return &KeyMgmtSDES{
-		Tag:   tag,
-		Suite: suite,
-		Key:   key,
-	}, nil
+	s.Tag = tag
+	s.Suite = suite
+	s.Key = key
+
+	return nil
 }

--- a/pkg/sdes/sdes_test.go
+++ b/pkg/sdes/sdes_test.go
@@ -1,0 +1,60 @@
+package sdes_test
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bluenviron/gortsplib/v5/pkg/sdes"
+)
+
+func TestUnmarshal(t *testing.T) {
+	// this exact inline key was captured from a real UniFi Protect camera's
+	// RTSPS ("?enableSrtp") DESCRIBE response.
+	const inlineKey = "5yQlV6XBpXYqEhsRoCs2OH+GujtAjltr3K6GPpyY"
+
+	expectedKey, err := base64.StdEncoding.DecodeString(inlineKey)
+	require.NoError(t, err)
+	require.Len(t, expectedKey, 30) // 16-byte master key + 14-byte master salt
+
+	var s sdes.SDES
+	err = s.Unmarshal("1 AES_CM_128_HMAC_SHA1_80 inline:" + inlineKey)
+	require.NoError(t, err)
+
+	require.Equal(t, sdes.SDES{
+		Tag:   1,
+		Suite: "AES_CM_128_HMAC_SHA1_80",
+		Key:   expectedKey,
+	}, s)
+}
+
+func TestUnmarshalErrors(t *testing.T) {
+	for _, ca := range []struct {
+		name string
+		v    string
+		err  string
+	}{
+		{
+			"missing fields",
+			"1 AES_CM_128_HMAC_SHA1_80",
+			"invalid crypto attribute: 1 AES_CM_128_HMAC_SHA1_80",
+		},
+		{
+			"non-inline key method",
+			"1 AES_CM_128_HMAC_SHA1_80 mikey:AQAFgM0=",
+			"unsupported crypto key method: mikey:AQAFgM0=",
+		},
+		{
+			"invalid base64",
+			"1 AES_CM_128_HMAC_SHA1_80 inline:not-valid-base64!!",
+			"invalid crypto inline key: illegal base64 data at input byte 3",
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			var s sdes.SDES
+			err := s.Unmarshal(ca.v)
+			require.EqualError(t, err, ca.err)
+		})
+	}
+}

--- a/wrapped_srtp_context.go
+++ b/wrapped_srtp_context.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pion/rtp"
 	"github.com/pion/srtp/v3"
 
-	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/bluenviron/gortsplib/v5/pkg/mikey"
 	"github.com/bluenviron/gortsplib/v5/pkg/ntp"
+	"github.com/bluenviron/gortsplib/v5/pkg/sdes"
 )
 
 func mikeyGetPayload[T mikey.Payload](mikeyMsg *mikey.Message) (T, bool) {
@@ -118,21 +118,21 @@ func mikeyToContext(mikeyMsg *mikey.Message) (*wrappedSRTPContext, error) {
 }
 
 // sdesToContext converts an SDES (RFC 4568) "a=crypto" attribute, as parsed
-// by pkg/description, into a wrappedSRTPContext. Unlike mikeyToContext, SDES
+// by pkg/sdes, into a wrappedSRTPContext. Unlike mikeyToContext, SDES
 // carries no per-SSRC starting ROC or MKI in-band, so those are left at
 // their zero values — correct here, since we're attaching to a stream fresh
 // at SETUP time.
-func sdesToContext(sdes *description.KeyMgmtSDES) (*wrappedSRTPContext, error) {
-	if sdes.Suite != "AES_CM_128_HMAC_SHA1_80" {
-		return nil, fmt.Errorf("unsupported SDES crypto suite: %v", sdes.Suite)
+func sdesToContext(sd *sdes.SDES) (*wrappedSRTPContext, error) {
+	if sd.Suite != "AES_CM_128_HMAC_SHA1_80" {
+		return nil, fmt.Errorf("unsupported SDES crypto suite: %v", sd.Suite)
 	}
 
-	if len(sdes.Key) != srtpKeyLength {
-		return nil, fmt.Errorf("unexpected SDES key size: %d", len(sdes.Key))
+	if len(sd.Key) != srtpKeyLength {
+		return nil, fmt.Errorf("unexpected SDES key size: %d", len(sd.Key))
 	}
 
 	srtpCtx := &wrappedSRTPContext{
-		key: sdes.Key,
+		key: sd.Key,
 	}
 	err := srtpCtx.initialize()
 	if err != nil {

--- a/wrapped_srtp_context.go
+++ b/wrapped_srtp_context.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pion/rtp"
 	"github.com/pion/srtp/v3"
 
+	"github.com/bluenviron/gortsplib/v5/pkg/description"
 	"github.com/bluenviron/gortsplib/v5/pkg/mikey"
 	"github.com/bluenviron/gortsplib/v5/pkg/ntp"
 )
@@ -107,6 +108,31 @@ func mikeyToContext(mikeyMsg *mikey.Message) (*wrappedSRTPContext, error) {
 		mki:       kemacPayload.SubPayloads[0].SPI,
 		ssrcs:     ssrcs,
 		startROCs: startROCs,
+	}
+	err := srtpCtx.initialize()
+	if err != nil {
+		return nil, err
+	}
+
+	return srtpCtx, nil
+}
+
+// sdesToContext converts an SDES (RFC 4568) "a=crypto" attribute, as parsed
+// by pkg/description, into a wrappedSRTPContext. Unlike mikeyToContext, SDES
+// carries no per-SSRC starting ROC or MKI in-band, so those are left at
+// their zero values — correct here, since we're attaching to a stream fresh
+// at SETUP time.
+func sdesToContext(sdes *description.KeyMgmtSDES) (*wrappedSRTPContext, error) {
+	if sdes.Suite != "AES_CM_128_HMAC_SHA1_80" {
+		return nil, fmt.Errorf("unsupported SDES crypto suite: %v", sdes.Suite)
+	}
+
+	if len(sdes.Key) != srtpKeyLength {
+		return nil, fmt.Errorf("unexpected SDES key size: %d", len(sdes.Key))
+	}
+
+	srtpCtx := &wrappedSRTPContext{
+		key: sdes.Key,
 	}
 	err := srtpCtx.initialize()
 	if err != nil {


### PR DESCRIPTION
## Summary

gortsplib currently only supports MIKEY (RFC 3830) for negotiating SRTP key material on secure RTSP sources. This adds support for SDES (RFC 4568), the key exchange method used by UniFi Protect cameras/NVRs when RTSPS streams have SRTP enabled (`?enableSrtp`).

## Changes

- **SDES parsing** (`pkg/description/sdes.go`, `pkg/description/media.go`): parse the SDP `a=crypto` attribute into a new `KeyMgmtSDES` field on `Media`, alongside the existing MIKEY `KeyMgmtMikey` field. Currently supports `AES_CM_128_HMAC_SHA1_80`, the suite these cameras use.
- **SRTP context construction** (`wrapped_srtp_context.go`): new `sdesToContext()`, building a `wrappedSRTPContext` directly from the SDES key/salt (no MKI/ROC handling needed, unlike MIKEY).
- **Client-side gating fix** (`client.go`): the client was only attempting inbound SRTP decryption when the SDP `m=` line's transport profile itself was secure (`RTP/SAVP`/`RTP/SAVPF`). Some servers — including these UniFi cameras — advertise `a=crypto` key material while still labeling the media line as plain `RTP/AVP`, so decryption was silently never attempted and undecrypted ciphertext was handed to the depacketizer. The gate now also considers whether the media actually carries MIKEY or SDES key material, not just the declared profile. This applies only when *playing* (not recording), since recording reuses caller-supplied `Media` objects whose key-mgmt fields are set as a side effect of describing our own outbound key material.

## Testing

- New unit tests for SDES parsing (`pkg/description/media_test.go`) and for the client's variant-handling behavior (`client_play_test.go`, `TestClientPlaySDESVariants`).
- Full existing test suite passes unchanged.
- Verified end-to-end against a real UniFi Protect NVR: RTSPS stream with `?enableSrtp`, confirmed genuine SRTP decryption (not just a passthrough) by cross-checking against `ffmpeg`'s independent SRTP implementation on the same stream, and by visually confirming clean, uncorrupted decoded H.264 video.