### PR TITLE
fix decoding and encoding fragmented MPEG-4 audio packets

### DIFF
--- a/pkg/format/rtpmpeg4audio/decoder.go
+++ b/pkg/format/rtpmpeg4audio/decoder.go
@@ -21,6 +21,74 @@ func joinFragments(fragments [][]byte, size int) []byte {
 	return ret
 }
 
+func readAUHeaders(
+	buf []byte,
+	headersLen int,
+	sizeLength int,
+	indexLength int,
+	indexDeltaLength int,
+) ([]uint64, error) {
+	firstHeaderLen := sizeLength + indexLength
+	otherHeaderLen := sizeLength + indexDeltaLength
+
+	if headersLen < firstHeaderLen {
+		return nil, fmt.Errorf("invalid AU-headers-length")
+	}
+
+	count := 1
+	remaining := headersLen - firstHeaderLen
+	for remaining > 0 {
+		if remaining < otherHeaderLen {
+			return nil, fmt.Errorf("invalid AU-headers-length")
+		}
+
+		remaining -= otherHeaderLen
+		count++
+	}
+
+	dataLens := make([]uint64, count)
+	pos := 0
+
+	for i := range dataLens {
+		dataLen, err := bits.ReadBits(buf, &pos, sizeLength)
+		if err != nil {
+			return nil, err
+		}
+
+		if dataLen == 0 {
+			return nil, fmt.Errorf("invalid data length")
+		}
+
+		if i == 0 {
+			if indexLength > 0 {
+				var auIndex uint64
+				auIndex, err = bits.ReadBits(buf, &pos, indexLength)
+				if err != nil {
+					return nil, err
+				}
+
+				if auIndex != 0 {
+					return nil, fmt.Errorf("AU-index different than zero is not supported")
+				}
+			}
+		} else if indexDeltaLength > 0 {
+			var auIndexDelta uint64
+			auIndexDelta, err = bits.ReadBits(buf, &pos, indexDeltaLength)
+			if err != nil {
+				return nil, err
+			}
+
+			if auIndexDelta != 0 {
+				return nil, fmt.Errorf("AU-index-delta different than zero is not supported")
+			}
+		}
+
+		dataLens[i] = dataLen
+	}
+
+	return dataLens, nil
+}
+
 // Decoder is a RTP/MPEG-4 Audio decoder.
 // Specification: RFC3640
 type Decoder struct {
@@ -37,17 +105,26 @@ type Decoder struct {
 	adtsMode           bool
 	fragments          [][]byte
 	fragmentsSize      int
+	fragmentAUSize     int
 	fragmentNextSeqNum uint16
+	fragmentTimestamp  uint32
 }
 
 // Init initializes the decoder.
 func (d *Decoder) Init() error {
+	if d.SizeLength == 0 {
+		return fmt.Errorf("invalid AU-size length")
+	}
+
 	return nil
 }
 
 func (d *Decoder) resetFragments() {
 	d.fragments = d.fragments[:0]
 	d.fragmentsSize = 0
+	d.fragmentAUSize = 0
+	d.fragmentNextSeqNum = 0
+	d.fragmentTimestamp = 0
 }
 
 // Decode decodes access units from a RTP packet.
@@ -66,25 +143,28 @@ func (d *Decoder) Decode(pkt *rtp.Packet) ([][]byte, error) {
 	payload := pkt.Payload[2:]
 
 	// AU-headers
-	dataLens, err := d.readAUHeaders(payload, headersLen)
+	dataLens, err := readAUHeaders(payload, headersLen, d.SizeLength, d.IndexLength, d.IndexDeltaLength)
 	if err != nil {
 		d.resetFragments()
 		return nil, err
 	}
 
-	pos := (headersLen / 8)
+	pos := headersLen / 8
 	if (headersLen % 8) != 0 {
 		pos++
+	}
+	if len(payload) < pos {
+		d.resetFragments()
+		return nil, fmt.Errorf("payload is too short")
 	}
 	payload = payload[pos:]
 
 	var aus [][]byte
 
-	if d.fragmentsSize == 0 {
+	if d.fragmentAUSize == 0 {
 		d.resetFragments()
 
 		if pkt.Marker {
-			// AUs
 			aus = make([][]byte, len(dataLens))
 			for i, dataLen := range dataLens {
 				if len(payload) < int(dataLen) {
@@ -94,18 +174,30 @@ func (d *Decoder) Decode(pkt *rtp.Packet) ([][]byte, error) {
 				aus[i] = payload[:dataLen]
 				payload = payload[dataLen:]
 			}
+
+			if len(payload) != 0 {
+				return nil, fmt.Errorf("payload has invalid size")
+			}
 		} else {
 			if len(dataLens) != 1 {
 				return nil, fmt.Errorf("a fragmented packet can only contain one AU")
 			}
 
-			if len(payload) < int(dataLens[0]) {
-				return nil, fmt.Errorf("payload is too short")
+			auSize := int(dataLens[0])
+			if auSize > mpeg4audio.MaxAccessUnitSize {
+				return nil, fmt.Errorf("access unit size (%d) is too big, maximum is %d",
+					auSize, mpeg4audio.MaxAccessUnitSize)
 			}
 
-			d.fragmentsSize = int(dataLens[0])
-			d.fragments = append(d.fragments, payload[:dataLens[0]])
+			if len(payload) == 0 || len(payload) >= auSize {
+				return nil, fmt.Errorf("invalid fragmented access unit")
+			}
+
+			d.fragmentsSize = len(payload)
+			d.fragmentAUSize = auSize
+			d.fragments = append(d.fragments, payload)
 			d.fragmentNextSeqNum = pkt.SequenceNumber + 1
+			d.fragmentTimestamp = pkt.Timestamp
 			return nil, ErrMorePacketsNeeded
 		}
 	} else {
@@ -115,9 +207,9 @@ func (d *Decoder) Decode(pkt *rtp.Packet) ([][]byte, error) {
 			return nil, fmt.Errorf("a fragmented packet can only contain one AU")
 		}
 
-		if len(payload) < int(dataLens[0]) {
+		if int(dataLens[0]) != d.fragmentAUSize {
 			d.resetFragments()
-			return nil, fmt.Errorf("payload is too short")
+			return nil, fmt.Errorf("AU size differs from previous fragment")
 		}
 
 		if pkt.SequenceNumber != d.fragmentNextSeqNum {
@@ -125,20 +217,32 @@ func (d *Decoder) Decode(pkt *rtp.Packet) ([][]byte, error) {
 			return nil, fmt.Errorf("discarding frame since a RTP packet is missing")
 		}
 
-		d.fragmentsSize += int(dataLens[0])
-
-		if d.fragmentsSize > mpeg4audio.MaxAccessUnitSize {
-			errSize := d.fragmentsSize
+		if pkt.Timestamp != d.fragmentTimestamp {
 			d.resetFragments()
-			return nil, fmt.Errorf("access unit size (%d) is too big, maximum is %d",
-				errSize, mpeg4audio.MaxAccessUnitSize)
+			return nil, fmt.Errorf("RTP timestamp differs from previous fragment")
 		}
 
-		d.fragments = append(d.fragments, payload[:dataLens[0]])
+		d.fragmentsSize += len(payload)
+		if d.fragmentsSize > d.fragmentAUSize {
+			d.resetFragments()
+			return nil, fmt.Errorf("access unit size exceeds declared size")
+		}
+
+		d.fragments = append(d.fragments, payload)
 		d.fragmentNextSeqNum++
 
 		if !pkt.Marker {
+			if d.fragmentsSize == d.fragmentAUSize {
+				d.resetFragments()
+				return nil, fmt.Errorf("invalid fragmented access unit")
+			}
+
 			return nil, ErrMorePacketsNeeded
+		}
+
+		if d.fragmentsSize != d.fragmentAUSize {
+			d.resetFragments()
+			return nil, fmt.Errorf("access unit size does not match declared size")
 		}
 
 		aus = [][]byte{joinFragments(d.fragments, d.fragmentsSize)}
@@ -146,71 +250,6 @@ func (d *Decoder) Decode(pkt *rtp.Packet) ([][]byte, error) {
 	}
 
 	return d.removeADTS(aus)
-}
-
-func (d *Decoder) readAUHeaders(buf []byte, headersLen int) ([]uint64, error) {
-	firstRead := false
-
-	count := 0
-	for i := 0; i < headersLen; {
-		if i == 0 {
-			i += d.SizeLength
-			i += d.IndexLength
-		} else {
-			i += d.SizeLength
-			i += d.IndexDeltaLength
-		}
-		count++
-	}
-
-	dataLens := make([]uint64, count)
-
-	pos := 0
-	i := 0
-
-	for headersLen > 0 {
-		dataLen, err := bits.ReadBits(buf, &pos, d.SizeLength)
-		if err != nil {
-			return nil, err
-		}
-		headersLen -= d.SizeLength
-
-		if dataLen == 0 {
-			return nil, fmt.Errorf("invalid data length")
-		}
-
-		if !firstRead {
-			firstRead = true
-			if d.IndexLength > 0 {
-				var auIndex uint64
-				auIndex, err = bits.ReadBits(buf, &pos, d.IndexLength)
-				if err != nil {
-					return nil, err
-				}
-				headersLen -= d.IndexLength
-
-				if auIndex != 0 {
-					return nil, fmt.Errorf("AU-index different than zero is not supported")
-				}
-			}
-		} else if d.IndexDeltaLength > 0 {
-			var auIndexDelta uint64
-			auIndexDelta, err = bits.ReadBits(buf, &pos, d.IndexDeltaLength)
-			if err != nil {
-				return nil, err
-			}
-			headersLen -= d.IndexDeltaLength
-
-			if auIndexDelta != 0 {
-				return nil, fmt.Errorf("AU-index-delta different than zero is not supported")
-			}
-		}
-
-		dataLens[i] = dataLen
-		i++
-	}
-
-	return dataLens, nil
 }
 
 // some cameras wrap AUs into ADTS

--- a/pkg/format/rtpmpeg4audio/decoder_test.go
+++ b/pkg/format/rtpmpeg4audio/decoder_test.go
@@ -45,6 +45,42 @@ func TestDecode(t *testing.T) {
 	}
 }
 
+func TestDecodeFragmented(t *testing.T) {
+	d := &Decoder{
+		SizeLength:       13,
+		IndexLength:      3,
+		IndexDeltaLength: 3,
+	}
+	err := d.Init()
+	require.NoError(t, err)
+
+	_, err = d.Decode(&rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			PayloadType:    96,
+			SequenceNumber: 100,
+			Timestamp:      90000,
+			SSRC:           0x9dbb7812,
+		},
+		Payload: []byte{0x00, 0x10, 0x00, 0x50, 0, 1, 2, 3},
+	})
+	require.Equal(t, ErrMorePacketsNeeded, err)
+
+	aus, err := d.Decode(&rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			Marker:         true,
+			PayloadType:    96,
+			SequenceNumber: 101,
+			Timestamp:      90000,
+			SSRC:           0x9dbb7812,
+		},
+		Payload: []byte{0x00, 0x10, 0x00, 0x50, 4, 5, 6, 7, 8, 9},
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}, aus)
+}
+
 func TestDecodeADTS(t *testing.T) {
 	d := &Decoder{
 		SizeLength:       13,
@@ -92,7 +128,7 @@ func TestDecodeErrorMissingPacket(t *testing.T) {
 			SSRC:           0x9dbb7812,
 		},
 		Payload: mergeBytes(
-			[]byte{0x0, 0x10, 0x2d, 0x80},
+			[]byte{0x0, 0x10, 0x3b, 0x00},
 			bytes.Repeat([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}, 182),
 		),
 	})
@@ -107,11 +143,40 @@ func TestDecodeErrorMissingPacket(t *testing.T) {
 			SSRC:           0x9dbb7812,
 		},
 		Payload: mergeBytes(
-			[]byte{0x00, 0x10, 0x2d, 0x80},
+			[]byte{0x00, 0x10, 0x3b, 0x00},
 			bytes.Repeat([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}, 182),
 		),
 	})
 	require.EqualError(t, err, "discarding frame since a RTP packet is missing")
+}
+
+func TestDecodeErrorCompletePacketTrailingData(t *testing.T) {
+	d := &Decoder{
+		SizeLength:       13,
+		IndexLength:      3,
+		IndexDeltaLength: 3,
+	}
+	err := d.Init()
+	require.NoError(t, err)
+
+	_, err = d.Decode(&rtp.Packet{
+		Header: rtp.Header{
+			Version:        2,
+			Marker:         true,
+			PayloadType:    96,
+			SequenceNumber: 100,
+			Timestamp:      90000,
+			SSRC:           0x9dbb7812,
+		},
+		Payload: []byte{0x00, 0x10, 0x00, 0x20, 0, 1, 2, 3, 4},
+	})
+	require.EqualError(t, err, "payload has invalid size")
+}
+
+func TestDecodeInit(t *testing.T) {
+	d := &Decoder{}
+	err := d.Init()
+	require.EqualError(t, err, "invalid AU-size length")
 }
 
 func serializePackets(packets []*rtp.Packet) ([]byte, error) {

--- a/pkg/format/rtpmpeg4audio/encoder.go
+++ b/pkg/format/rtpmpeg4audio/encoder.go
@@ -139,7 +139,8 @@ func (e *Encoder) writeFragmented(au []byte, timestamp uint32) ([]*rtp.Packet, e
 	}
 
 	avail := e.PayloadMaxSize - 2 - auHeadersLenBytes
-	le := len(au)
+	auSize := len(au)
+	le := auSize
 	packetCount := packetCount(avail, le)
 
 	ret := make([]*rtp.Packet, packetCount)
@@ -158,7 +159,7 @@ func (e *Encoder) writeFragmented(au []byte, timestamp uint32) ([]*rtp.Packet, e
 
 		// AU-headers
 		pos := 0
-		bits.WriteBitsUnsafe(payload[2:], &pos, uint64(le), e.SizeLength)
+		bits.WriteBitsUnsafe(payload[2:], &pos, uint64(auSize), e.SizeLength)
 		bits.WriteBitsUnsafe(payload[2:], &pos, 0, e.IndexLength)
 
 		// AU

--- a/pkg/format/rtpmpeg4audio/encoder_test.go
+++ b/pkg/format/rtpmpeg4audio/encoder_test.go
@@ -42,6 +42,7 @@ var cases = []struct {
 	sizeLength       int
 	indexLength      int
 	indexDeltaLength int
+	payloadMaxSize   int
 	aus              [][]byte
 	pkts             []*rtp.Packet
 }{
@@ -50,6 +51,7 @@ var cases = []struct {
 		13,
 		3,
 		3,
+		1000,
 		[][]byte{
 			{
 				0x21, 0x1a, 0xd4, 0xf5, 0x9e, 0x20, 0xc5, 0x42,
@@ -162,6 +164,7 @@ var cases = []struct {
 		13,
 		3,
 		3,
+		1000,
 		[][]byte{
 			{0x00, 0x01, 0x02, 0x03},
 			{0x04, 0x05, 0x06, 0x07},
@@ -189,6 +192,7 @@ var cases = []struct {
 		13,
 		3,
 		3,
+		1000,
 		[][]byte{
 			bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7}, 187),
 		},
@@ -202,7 +206,7 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x0, 0x10, 0x1f, 0x20},
+					[]byte{0x0, 0x10, 0x2e, 0xc0},
 					bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7}, 124),
 					[]byte{0, 1, 2, 3},
 				),
@@ -216,7 +220,7 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x00, 0x10, 0x0f, 0xa0},
+					[]byte{0x00, 0x10, 0x2e, 0xc0},
 					[]byte{4, 5, 6, 7},
 					bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7}, 62),
 				),
@@ -224,11 +228,12 @@ var cases = []struct {
 		},
 	},
 	{
-		"fragmented to the limit",
+		"fragmented, payload max size",
 		13,
 		3,
 		3,
-		[][]byte{bytes.Repeat([]byte{1}, 1992)},
+		688,
+		[][]byte{bytes.Repeat([]byte{0x01}, 685)},
 		[]*rtp.Packet{
 			{
 				Header: rtp.Header{
@@ -239,8 +244,8 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x0, 0x10, 0x1f, 0x20},
-					bytes.Repeat([]byte{1}, 996),
+					[]byte{0x00, 0x10, 0x15, 0x68},
+					bytes.Repeat([]byte{0x01}, 684),
 				),
 			},
 			{
@@ -251,10 +256,7 @@ var cases = []struct {
 					SequenceNumber: 17646,
 					SSRC:           0x9dbb7812,
 				},
-				Payload: mergeBytes(
-					[]byte{0x0, 0x10, 0x1f, 0x20},
-					bytes.Repeat([]byte{1}, 996),
-				),
+				Payload: []byte{0x00, 0x10, 0x15, 0x68, 0x01},
 			},
 		},
 	},
@@ -263,6 +265,7 @@ var cases = []struct {
 		13,
 		3,
 		3,
+		1000,
 		[][]byte{
 			{0x00, 0x01, 0x02, 0x03},
 			{0x04, 0x05, 0x06, 0x07},
@@ -294,7 +297,7 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x0, 0x10, 0x1f, 0x20},
+					[]byte{0x0, 0x10, 0x2e, 0xc0},
 					bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7}, 124),
 					[]byte{0, 1, 2, 3},
 				),
@@ -309,7 +312,7 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x00, 0x10, 0x0f, 0xa0},
+					[]byte{0x00, 0x10, 0x2e, 0xc0},
 					[]byte{4, 5, 6, 7},
 					bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7}, 62),
 				),
@@ -321,6 +324,7 @@ var cases = []struct {
 		6,
 		2,
 		2,
+		1000,
 		[][]byte{
 			{0x01, 0x02, 0x03, 0x04},
 		},
@@ -345,6 +349,7 @@ var cases = []struct {
 		13,
 		0,
 		0,
+		1000,
 		[][]byte{
 			{0x01, 0x02, 0x03, 0x04},
 		},
@@ -369,6 +374,7 @@ var cases = []struct {
 		13,
 		0,
 		0,
+		1000,
 		[][]byte{
 			{0x01, 0x02, 0x03, 0x04},
 			{0x05, 0x06, 0x07, 0x08},
@@ -395,6 +401,7 @@ var cases = []struct {
 		21,
 		3,
 		3,
+		1000,
 		[][]byte{
 			bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7}, 187),
 		},
@@ -408,7 +415,7 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x0, 0x18, 0x00, 0x1f, 0x18},
+					[]byte{0x0, 0x18, 0x00, 0x2e, 0xc0},
 					bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7}, 124),
 					[]byte{0, 1, 2},
 				),
@@ -422,7 +429,7 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x00, 0x18, 0x00, 0x0f, 0xa8},
+					[]byte{0x00, 0x18, 0x00, 0x2e, 0xc0},
 					[]byte{3, 4, 5, 6, 7},
 					bytes.Repeat([]byte{0, 1, 2, 3, 4, 5, 6, 7}, 62),
 				),
@@ -434,6 +441,7 @@ var cases = []struct {
 		13,
 		0,
 		0,
+		1000,
 		[][]byte{
 			bytes.Repeat([]byte{0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}, 187),
 		},
@@ -447,7 +455,7 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x0, 0x0d, 0x1f, 0x20},
+					[]byte{0x0, 0x0d, 0x2e, 0xc0},
 					bytes.Repeat([]byte{0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}, 124),
 					[]byte{0x08, 0x09, 0x0A, 0x0B},
 				),
@@ -461,7 +469,7 @@ var cases = []struct {
 					SSRC:           0x9dbb7812,
 				},
 				Payload: mergeBytes(
-					[]byte{0x0, 0x0d, 0x0f, 0xa0},
+					[]byte{0x0, 0x0d, 0x2e, 0xc0},
 					[]byte{0x0C, 0x0D, 0x0E, 0x0F},
 					bytes.Repeat([]byte{0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}, 62),
 				),
@@ -480,7 +488,7 @@ func TestEncode(t *testing.T) {
 				SizeLength:            ca.sizeLength,
 				IndexLength:           ca.indexLength,
 				IndexDeltaLength:      ca.indexDeltaLength,
-				PayloadMaxSize:        1000,
+				PayloadMaxSize:        ca.payloadMaxSize,
 			}
 			err := e.Init()
 			require.NoError(t, err)


### PR DESCRIPTION
The AU-size field was set incorrectly in subsegment fragments.