### PR TITLE
rtpav1: do not set Y/Z bits when no OBU bytes were written

### DIFF
--- a/pkg/format/rtpav1/encoder.go
+++ b/pkg/format/rtpav1/encoder.go
@@ -135,11 +135,16 @@ func (e *Encoder) Encode(obus [][]byte) ([]*rtp.Packet, error) {
 				break
 			}
 
+			// the remaining space can be too small to hold any byte of the OBU.
+			// in that case the OBU is not fragmented and Y / Z must not be set.
+			fragmented := false
+
 			if omitSize {
 				if avail > 0 {
 					curPacket.Payload[0] |= byte((obusInPacket + 1) << 4) // W
 					curPacket.Payload = append(curPacket.Payload, obu[:avail]...)
 					obu = obu[avail:]
+					fragmented = true
 				}
 			} else {
 				if avail > maxFragmentedLEBSize {
@@ -152,11 +157,12 @@ func (e *Encoder) Encode(obus [][]byte) ([]*rtp.Packet, error) {
 					curPacket.Payload = append(curPacket.Payload, buf...)
 					curPacket.Payload = append(curPacket.Payload, obu[:fragmentLen]...)
 					obu = obu[fragmentLen:]
+					fragmented = true
 				}
 			}
 
-			finalizeCurPacket(true)
-			createNewPacket(true)
+			finalizeCurPacket(fragmented)
+			createNewPacket(fragmented)
 		}
 	}
 

--- a/pkg/format/rtpav1/encoder_test.go
+++ b/pkg/format/rtpav1/encoder_test.go
@@ -1,6 +1,8 @@
 package rtpav1
 
 import (
+	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/pion/rtp"
@@ -1003,4 +1005,62 @@ func TestEncodeRandomInitialState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, nil, e.SSRC)
 	require.NotEqual(t, nil, e.InitialSequenceNumber)
+}
+
+func TestEncodeNoZeroSizedFragment(t *testing.T) {
+	// when an OBU exactly fills a packet, the next OBU is moved to a new
+	// packet without writing any of its bytes: the Y and Z bits must stay
+	// unset, otherwise receivers join the two OBUs into one.
+	for _, ca := range []struct {
+		name string
+		obus [][]byte
+	}{
+		{
+			"omit size",
+			[][]byte{bytes.Repeat([]byte{0x01}, 997), bytes.Repeat([]byte{0x02}, 100)},
+		},
+		{
+			"with size",
+			[][]byte{
+				bytes.Repeat([]byte{0x01}, 997),
+				bytes.Repeat([]byte{0x02}, 10),
+				bytes.Repeat([]byte{0x03}, 10),
+				bytes.Repeat([]byte{0x04}, 10),
+			},
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			e := &Encoder{
+				PayloadType:           96,
+				SSRC:                  new(uint32(0x9dbb7812)),
+				InitialSequenceNumber: new(uint16(0x44ed)),
+				PayloadMaxSize:        1000,
+			}
+			err := e.Init()
+			require.NoError(t, err)
+
+			pkts, err := e.Encode(ca.obus)
+			require.NoError(t, err)
+			require.Equal(t, byte(0), pkts[0].Payload[0]&(1<<6))
+			require.Equal(t, byte(0), pkts[1].Payload[0]&(1<<7))
+
+			var d Decoder
+			err = d.Init()
+			require.NoError(t, err)
+
+			var decoded [][]byte
+
+			for _, pkt := range pkts {
+				var addOBUs [][]byte
+				addOBUs, err = d.Decode(pkt)
+				if errors.Is(err, ErrMorePacketsNeeded) {
+					continue
+				}
+				require.NoError(t, err)
+				decoded = append(decoded, addOBUs...)
+			}
+
+			require.Equal(t, ca.obus, decoded)
+		})
+	}
 }

--- a/pkg/format/rtpav1/encoder_test.go
+++ b/pkg/format/rtpav1/encoder_test.go
@@ -2,7 +2,6 @@ package rtpav1
 
 import (
 	"bytes"
-	"errors"
 	"testing"
 
 	"github.com/pion/rtp"
@@ -976,6 +975,46 @@ var cases = []struct {
 			},
 		},
 	},
+	{
+		"packet filled to the limit",
+		[][]byte{
+			bytes.Repeat([]byte{0x01}, 997),
+			bytes.Repeat([]byte{0x02}, 10),
+			bytes.Repeat([]byte{0x03}, 10),
+			bytes.Repeat([]byte{0x04}, 10),
+		},
+		[]*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         false,
+					PayloadType:    96,
+					SequenceNumber: 17645,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: bytes.Join([][]byte{
+					{0x00, 0xe5, 0x07},
+					bytes.Repeat([]byte{0x01}, 997),
+				}, nil),
+			},
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 17646,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: bytes.Join([][]byte{
+					{0x30, 0x0a},
+					bytes.Repeat([]byte{0x02}, 10),
+					{0x0a},
+					bytes.Repeat([]byte{0x03}, 10),
+					bytes.Repeat([]byte{0x04}, 10),
+				}, nil),
+			},
+		},
+	},
 }
 
 func TestEncode(t *testing.T) {
@@ -1005,62 +1044,4 @@ func TestEncodeRandomInitialState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, nil, e.SSRC)
 	require.NotEqual(t, nil, e.InitialSequenceNumber)
-}
-
-func TestEncodeNoZeroSizedFragment(t *testing.T) {
-	// when an OBU exactly fills a packet, the next OBU is moved to a new
-	// packet without writing any of its bytes: the Y and Z bits must stay
-	// unset, otherwise receivers join the two OBUs into one.
-	for _, ca := range []struct {
-		name string
-		obus [][]byte
-	}{
-		{
-			"omit size",
-			[][]byte{bytes.Repeat([]byte{0x01}, 997), bytes.Repeat([]byte{0x02}, 100)},
-		},
-		{
-			"with size",
-			[][]byte{
-				bytes.Repeat([]byte{0x01}, 997),
-				bytes.Repeat([]byte{0x02}, 10),
-				bytes.Repeat([]byte{0x03}, 10),
-				bytes.Repeat([]byte{0x04}, 10),
-			},
-		},
-	} {
-		t.Run(ca.name, func(t *testing.T) {
-			e := &Encoder{
-				PayloadType:           96,
-				SSRC:                  new(uint32(0x9dbb7812)),
-				InitialSequenceNumber: new(uint16(0x44ed)),
-				PayloadMaxSize:        1000,
-			}
-			err := e.Init()
-			require.NoError(t, err)
-
-			pkts, err := e.Encode(ca.obus)
-			require.NoError(t, err)
-			require.Equal(t, byte(0), pkts[0].Payload[0]&(1<<6))
-			require.Equal(t, byte(0), pkts[1].Payload[0]&(1<<7))
-
-			var d Decoder
-			err = d.Init()
-			require.NoError(t, err)
-
-			var decoded [][]byte
-
-			for _, pkt := range pkts {
-				var addOBUs [][]byte
-				addOBUs, err = d.Decode(pkt)
-				if errors.Is(err, ErrMorePacketsNeeded) {
-					continue
-				}
-				require.NoError(t, err)
-				decoded = append(decoded, addOBUs...)
-			}
-
-			require.Equal(t, ca.obus, decoded)
-		})
-	}
 }


### PR DESCRIPTION
When the space left in a packet is too small to hold any byte of the next OBU, the encoder writes nothing into that packet but still marks it with Y=1 and marks the following packet with Z=1.

The AV1 RTP payload format (v1.0, section 4.4) says Y "MUST be set to 1 if the last OBU element is an OBU fragment that will continue in the next packet, and MUST be set to 0 otherwise", and Z the same for a continuation at the start of a packet. Nothing was fragmented here, so both must be 0.

Receivers that honor the bits join the two complete OBUs into a single one. I checked this against the decoder in this package, against pion/rtp, and the same handling is in ffmpeg's rtpdec_av1. There is no error anywhere, the OBU is just silently lost.

It is reachable whenever an earlier OBU leaves exactly 0 free bytes in the packet, or 0 to 2 bytes when the next OBU is size-prefixed. With the default payload size those first-OBU sizes are 1447 and 1445-1447. This affects streams that get repacketized rather than forwarded, for instance non-RTSP sources read over RTSP in mediamtx.

The fix only sets the two bits when bytes were actually written; when nothing fits, the OBU is retried in the fresh packet as before. Added encode/decode round-trip tests for both the omit-size and the size-prefixed path (they fail without the change).