### PR TITLE
rtpklv: do not reuse buffer of returned KLV units

### DIFF
--- a/pkg/format/rtpklv/decoder.go
+++ b/pkg/format/rtpklv/decoder.go
@@ -42,7 +42,7 @@ func (d *Decoder) Init() error {
 
 // reset clears the decoder state.
 func (d *Decoder) reset() {
-	d.buffer = d.buffer[:0]
+	d.buffer = nil // do not reuse buffer to avoid race conditions
 	d.expectedSize = 0
 	d.currentTimestamp = 0
 	d.assembling = false

--- a/pkg/format/rtpklv/decoder_test.go
+++ b/pkg/format/rtpklv/decoder_test.go
@@ -1,6 +1,7 @@
 package rtpklv
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"testing"
@@ -130,4 +131,59 @@ func FuzzDecoder(f *testing.F) {
 			e.Encode(unit) //nolint:errcheck
 		}
 	})
+}
+
+func TestDecodeUnitsAreNotReused(t *testing.T) {
+	klvUnit := func(fill byte, size int) []byte {
+		return append([]byte{
+			0x06, 0x0e, 0x2b, 0x34, 0x02, 0x0b, 0x01, 0x01,
+			0x0e, 0x01, 0x03, 0x01, 0x01, 0x00, 0x00, 0x00,
+			byte(size),
+		}, bytes.Repeat([]byte{fill}, size)...)
+	}
+
+	for _, ca := range []struct {
+		name   string
+		second []byte
+	}{
+		{"same size", klvUnit(0xbb, 20)},
+		{"shorter", klvUnit(0xbb, 8)},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			var d Decoder
+			err := d.Init()
+			require.NoError(t, err)
+
+			first := klvUnit(0xaa, 20)
+
+			decoded, err := d.Decode(&rtp.Packet{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					SequenceNumber: 17645,
+					Timestamp:      2289526357,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: first,
+			})
+			require.NoError(t, err)
+			require.Equal(t, first, decoded)
+
+			_, err = d.Decode(&rtp.Packet{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					SequenceNumber: 17646,
+					Timestamp:      2289529357,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: ca.second,
+			})
+			require.NoError(t, err)
+
+			// the unit returned by the first Decode() must not be touched
+			// by the second one.
+			require.Equal(t, first, decoded)
+		})
+	}
 }


### PR DESCRIPTION
`Decode()` returns a slice that points into the decoder's internal buffer, and the next call to `Decode()` overwrites that same array in place (`reset()` truncates it to zero length, then the next unit is appended into it).

A caller that still holds the previous unit therefore ends up reading the bytes of the next one, or a torn mix of the two when the sizes differ. In mediamtx the decoded unit is handed to readers through a ring buffer and consumed on a different goroutine (recorder, HLS, MPEG-TS, WebRTC), so this is also a data race.

rtpklv is the only decoder under pkg/format that returns its own reusable state. The others either build a fresh slice in joinFragments() or clear the buffer, with the comment "do not reuse frameBuffer to avoid race conditions" in rtph264, rtph265, rtpav1, rtpvp8 and rtpmpeg1video.

The fix clears the buffer instead of truncating it, so every unit gets its own array. It costs one allocation per KLV unit, the same tradeoff the other decoders already make. Tests cover a following unit of the same size and a shorter one.