### PR TITLE
auth: support qop=auth in digest client (#1074)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ In RTSP, media streams are transmitted by using RTP packets, which are encoded i
 |[RFC4567, Key Management Extensions for Session Description Protocol (SDP) and Real Time Streaming Protocol (RTSP)](https://datatracker.ietf.org/doc/html/rfc4567)|secure variants|
 |[RFC3830, MIKEY: Multimedia Internet KEYing](https://datatracker.ietf.org/doc/html/rfc3830)|secure variants|
 |[RFC4568, SDP Security Descriptions for Media Streams](https://datatracker.ietf.org/doc/html/rfc4568)|secure variants|
+|[RFC2069, An Extension to HTTP : Digest Access Authentication](https://datatracker.ietf.org/doc/html/rfc2069)|digest authentication|
+|[RFC7616, HTTP Digest Access Authentication](https://datatracker.ietf.org/doc/html/rfc7616)|digest authentication|
 |[RTP Payload Format For AV1 (v1.0)](https://aomediacodec.github.io/av1-rtp-spec/)|payload formats / AV1|
 |[RFC9628, RTP Payload Format for VP9 Video](https://datatracker.ietf.org/doc/html/rfc9628)|payload formats / VP9|
 |[RFC7741, RTP Payload Format for VP8 Video](https://datatracker.ietf.org/doc/html/rfc7741)|payload formats / VP8|

--- a/pkg/auth/sender.go
+++ b/pkg/auth/sender.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
 	"github.com/bluenviron/gortsplib/v5/pkg/headers"
@@ -16,6 +18,9 @@ type Sender struct {
 	Pass    string
 
 	authHeader *headers.Authenticate
+	qop        string
+	cnonce     string
+	nonceCount uint32
 }
 
 // Initialize initializes a Sender.
@@ -38,6 +43,24 @@ func (se *Sender) Initialize() error {
 		return fmt.Errorf("no authentication methods available")
 	}
 
+	// among the offered qop values, only "auth" is supported.
+	// when it is absent, fall back to the legacy computation (RFC 2069).
+	if se.authHeader.Qop != nil {
+		for qop := range strings.SplitSeq(*se.authHeader.Qop, ",") {
+			if strings.TrimSpace(qop) == "auth" {
+				se.qop = "auth"
+
+				var err error
+				se.cnonce, err = GenerateNonce()
+				if err != nil {
+					return err
+				}
+
+				break
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -58,13 +81,29 @@ func (se *Sender) AddAuthorization(req *base.Request) {
 		h.Nonce = se.authHeader.Nonce
 		h.URI = urStr
 		h.Algorithm = se.authHeader.Algorithm
+		h.Opaque = se.authHeader.Opaque
+
+		// the nonce count must increase at every request that uses the same nonce.
+		middle := se.authHeader.Nonce
+
+		if se.qop != "" {
+			se.nonceCount++
+			nc := strconv.FormatUint(uint64(se.nonceCount), 16)
+			nc = strings.Repeat("0", 8-len(nc)) + nc
+
+			h.Qop = &se.qop
+			h.Cnonce = &se.cnonce
+			h.Nc = &nc
+
+			middle += ":" + nc + ":" + se.cnonce + ":" + se.qop
+		}
 
 		if se.authHeader.Algorithm == nil || *se.authHeader.Algorithm == headers.AuthAlgorithmMD5 {
 			h.Response = md5Hex(md5Hex(se.User+":"+se.authHeader.Realm+":"+se.Pass) + ":" +
-				se.authHeader.Nonce + ":" + md5Hex(string(req.Method)+":"+urStr))
+				middle + ":" + md5Hex(string(req.Method)+":"+urStr))
 		} else { // sha256
 			h.Response = sha256Hex(sha256Hex(se.User+":"+se.authHeader.Realm+":"+se.Pass) + ":" +
-				se.authHeader.Nonce + ":" + sha256Hex(string(req.Method)+":"+urStr))
+				middle + ":" + sha256Hex(string(req.Method)+":"+urStr))
 		}
 	}
 

--- a/pkg/auth/sender.go
+++ b/pkg/auth/sender.go
@@ -9,6 +9,17 @@ import (
 	"github.com/bluenviron/gortsplib/v5/pkg/headers"
 )
 
+func hasQOPAuth(qop *string) bool {
+	if qop != nil {
+		for v := range strings.SplitSeq(*qop, ",") {
+			if strings.TrimSpace(v) == "auth" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Sender allows to send credentials.
 // It requires a WWW-Authenticate header (provided by the server)
 // and a set of credentials.
@@ -18,7 +29,7 @@ type Sender struct {
 	Pass    string
 
 	authHeader *headers.Authenticate
-	qop        string
+	hasQOPAuth bool
 	cnonce     string
 	nonceCount uint32
 }
@@ -43,21 +54,13 @@ func (se *Sender) Initialize() error {
 		return fmt.Errorf("no authentication methods available")
 	}
 
-	// among the offered qop values, only "auth" is supported.
-	// when it is absent, fall back to the legacy computation (RFC 2069).
-	if se.authHeader.Qop != nil {
-		for qop := range strings.SplitSeq(*se.authHeader.Qop, ",") {
-			if strings.TrimSpace(qop) == "auth" {
-				se.qop = "auth"
+	if hasQOPAuth(se.authHeader.Qop) {
+		se.hasQOPAuth = true
 
-				var err error
-				se.cnonce, err = GenerateNonce()
-				if err != nil {
-					return err
-				}
-
-				break
-			}
+		var err error
+		se.cnonce, err = GenerateNonce()
+		if err != nil {
+			return err
 		}
 	}
 
@@ -86,16 +89,17 @@ func (se *Sender) AddAuthorization(req *base.Request) {
 		// the nonce count must increase at every request that uses the same nonce.
 		middle := se.authHeader.Nonce
 
-		if se.qop != "" {
+		if se.hasQOPAuth {
 			se.nonceCount++
 			nc := strconv.FormatUint(uint64(se.nonceCount), 16)
 			nc = strings.Repeat("0", 8-len(nc)) + nc
 
-			h.Qop = &se.qop
+			qop := "auth"
+			h.Qop = &qop
 			h.Cnonce = &se.cnonce
 			h.Nc = &nc
 
-			middle += ":" + nc + ":" + se.cnonce + ":" + se.qop
+			middle += ":" + nc + ":" + se.cnonce + ":" + qop
 		}
 
 		if se.authHeader.Algorithm == nil || *se.authHeader.Algorithm == headers.AuthAlgorithmMD5 {

--- a/pkg/auth/sender.go
+++ b/pkg/auth/sender.go
@@ -86,10 +86,10 @@ func (se *Sender) AddAuthorization(req *base.Request) {
 		h.Algorithm = se.authHeader.Algorithm
 		h.Opaque = se.authHeader.Opaque
 
-		// the nonce count must increase at every request that uses the same nonce.
 		middle := se.authHeader.Nonce
 
 		if se.hasQOPAuth {
+			// the nonce count must increase at every request that uses the same nonce.
 			se.nonceCount++
 			nc := strconv.FormatUint(uint64(se.nonceCount), 16)
 			nc = strings.Repeat("0", 8-len(nc)) + nc

--- a/pkg/auth/sender_test.go
+++ b/pkg/auth/sender_test.go
@@ -1,12 +1,16 @@
 package auth_test
 
 import (
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/bluenviron/gortsplib/v5/pkg/auth"
 	"github.com/bluenviron/gortsplib/v5/pkg/base"
+	"github.com/bluenviron/gortsplib/v5/pkg/headers"
 )
 
 var casesSender = []struct {
@@ -126,4 +130,128 @@ func FuzzSender(f *testing.F) {
 			URL:    mustParseURL("rtsp://myhost/mypath?key=val/trackID=3"),
 		})
 	})
+}
+
+func testMD5(in string) string {
+	h := md5.Sum([]byte(in))
+	return hex.EncodeToString(h[:])
+}
+
+func testSHA256(in string) string {
+	h := sha256.Sum256([]byte(in))
+	return hex.EncodeToString(h[:])
+}
+
+func TestSenderQop(t *testing.T) {
+	const nonce = "f49ac6dd0ba708d4becddc9692d1f2ce"
+	const uri = "rtsp://myhost/mypath?key=val/trackID=3"
+
+	for _, ca := range []struct {
+		name string
+		www  string
+		hash func(string) string
+	}{
+		{
+			"md5",
+			`Digest realm="myrealm", nonce="` + nonce + `", qop="auth", algorithm="MD5"`,
+			testMD5,
+		},
+		{
+			"sha256",
+			`Digest realm="myrealm", nonce="` + nonce + `", qop="auth", algorithm="SHA-256"`,
+			testSHA256,
+		},
+		{
+			"multiple qop values",
+			`Digest realm="myrealm", nonce="` + nonce + `", qop="auth-int,auth"`,
+			testMD5,
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			se := &auth.Sender{
+				WWWAuth: base.HeaderValue{ca.www},
+				User:    "myuser",
+				Pass:    "mypass",
+			}
+			err := se.Initialize()
+			require.NoError(t, err)
+
+			req := &base.Request{
+				Method: base.Setup,
+				URL:    mustParseURL(uri),
+			}
+			se.AddAuthorization(req)
+
+			var h headers.Authorization
+			err = h.Unmarshal(req.Header["Authorization"])
+			require.NoError(t, err)
+
+			require.Equal(t, "auth", *h.Qop)
+			require.Equal(t, "00000001", *h.Nc)
+			require.NotEmpty(t, *h.Cnonce)
+
+			// RFC 7616, section 3.4.1
+			ha1 := ca.hash("myuser:myrealm:mypass")
+			ha2 := ca.hash("SETUP:" + uri)
+			require.Equal(t, ca.hash(ha1+":"+nonce+":00000001:"+*h.Cnonce+":auth:"+ha2), h.Response)
+		})
+	}
+}
+
+func TestSenderQopNonceCount(t *testing.T) {
+	se := &auth.Sender{
+		WWWAuth: base.HeaderValue{
+			`Digest realm="myrealm", nonce="f49ac6dd0ba708d4becddc9692d1f2ce", qop="auth"`,
+		},
+		User: "myuser",
+		Pass: "mypass",
+	}
+	err := se.Initialize()
+	require.NoError(t, err)
+
+	var cnonce string
+
+	for i, expected := range []string{"00000001", "00000002", "00000003"} {
+		req := &base.Request{
+			Method: base.Setup,
+			URL:    mustParseURL("rtsp://myhost/mypath"),
+		}
+		se.AddAuthorization(req)
+
+		var h headers.Authorization
+		err = h.Unmarshal(req.Header["Authorization"])
+		require.NoError(t, err)
+		require.Equal(t, expected, *h.Nc)
+
+		// the client nonce stays the same for the whole session.
+		if i == 0 {
+			cnonce = *h.Cnonce
+		} else {
+			require.Equal(t, cnonce, *h.Cnonce)
+		}
+	}
+}
+
+func TestSenderOpaque(t *testing.T) {
+	se := &auth.Sender{
+		WWWAuth: base.HeaderValue{
+			`Digest realm="myrealm", nonce="f49ac6dd0ba708d4becddc9692d1f2ce", ` +
+				`opaque="5ccc069c403ebaf9f0171e9517f40e41"`,
+		},
+		User: "myuser",
+		Pass: "mypass",
+	}
+	err := se.Initialize()
+	require.NoError(t, err)
+
+	req := &base.Request{
+		Method: base.Setup,
+		URL:    mustParseURL("rtsp://myhost/mypath"),
+	}
+	se.AddAuthorization(req)
+
+	var h headers.Authorization
+	err = h.Unmarshal(req.Header["Authorization"])
+	require.NoError(t, err)
+	require.Equal(t, "5ccc069c403ebaf9f0171e9517f40e41", *h.Opaque)
 }

--- a/pkg/headers/authenticate.go
+++ b/pkg/headers/authenticate.go
@@ -60,6 +60,9 @@ type Authenticate struct {
 	// stale
 	Stale *string
 
+	// qop
+	Qop *string
+
 	// algorithm
 	Algorithm *AuthAlgorithm
 }
@@ -136,6 +139,9 @@ func (h *Authenticate) Unmarshal(v base.HeaderValue) error {
 			case "opaque":
 				h.Opaque = &v
 
+			case "qop":
+				h.Qop = &v
+
 			case "stale":
 				h.Stale = &v
 
@@ -172,6 +178,10 @@ func (h Authenticate) Marshal() base.HeaderValue {
 
 	if h.Stale != nil {
 		ret += ", stale=\"" + *h.Stale + "\""
+	}
+
+	if h.Qop != nil {
+		ret += ", qop=\"" + *h.Qop + "\""
 	}
 
 	if h.Algorithm != nil {

--- a/pkg/headers/authenticate_test.go
+++ b/pkg/headers/authenticate_test.go
@@ -24,6 +24,18 @@ var casesAuthenticate = []struct {
 		},
 	},
 	{
+		"digest with qop",
+		base.HeaderValue{`Digest realm="4419b63f5e51", nonce="8b84a3b789283a8bea8da7fa7d41f08b", qop="auth"`},
+		base.HeaderValue{`Digest realm="4419b63f5e51", nonce="8b84a3b789283a8bea8da7fa7d41f08b", ` +
+			`qop="auth"`},
+		Authenticate{
+			Method: AuthMethodDigest,
+			Realm:  "4419b63f5e51",
+			Nonce:  "8b84a3b789283a8bea8da7fa7d41f08b",
+			Qop:    new("auth"),
+		},
+	},
+	{
 		"digest 1",
 		base.HeaderValue{`Digest realm="4419b63f5e51", nonce="8b84a3b789283a8bea8da7fa7d41f08b", stale="FALSE"`},
 		base.HeaderValue{`Digest realm="4419b63f5e51", nonce="8b84a3b789283a8bea8da7fa7d41f08b", ` +

--- a/pkg/headers/authorization.go
+++ b/pkg/headers/authorization.go
@@ -44,6 +44,15 @@ type Authorization struct {
 
 	// algorithm
 	Algorithm *AuthAlgorithm
+
+	// quality of protection
+	Qop *string
+
+	// client nonce
+	Cnonce *string
+
+	// nonce count
+	Nc *string
 }
 
 // Unmarshal decodes an Authorization header.
@@ -125,6 +134,15 @@ func (h *Authorization) Unmarshal(v base.HeaderValue) error {
 			case "opaque":
 				h.Opaque = &v
 
+			case "qop":
+				h.Qop = &v
+
+			case "cnonce":
+				h.Cnonce = &v
+
+			case "nc":
+				h.Nc = &v
+
 			case "algorithm":
 				var a AuthAlgorithm
 				a, err = parseAuthAlgorithm(v)
@@ -156,6 +174,19 @@ func (h Authorization) Marshal() base.HeaderValue {
 
 	if h.Opaque != nil {
 		ret += ", opaque=\"" + *h.Opaque + "\""
+	}
+
+	// qop and nc are tokens and must not be enclosed in apexes (RFC 7616, section 3.4).
+	if h.Qop != nil {
+		ret += ", qop=" + *h.Qop
+	}
+
+	if h.Nc != nil {
+		ret += ", nc=" + *h.Nc
+	}
+
+	if h.Cnonce != nil {
+		ret += ", cnonce=\"" + *h.Cnonce + "\""
 	}
 
 	if h.Algorithm != nil {

--- a/pkg/headers/authorization_test.go
+++ b/pkg/headers/authorization_test.go
@@ -25,6 +25,28 @@ var casesAuthorization = []struct {
 		},
 	},
 	{
+		"digest with qop",
+		base.HeaderValue{`Digest username="Mufasa", realm="http-auth@example.org", ` +
+			`nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", uri="/dir/index.html", ` +
+			`response="8ca523f5e9506fed4657c9700eebdbec", qop=auth, nc=00000001, ` +
+			`cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"`},
+		base.HeaderValue{`Digest username="Mufasa", realm="http-auth@example.org", ` +
+			`nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", uri="/dir/index.html", ` +
+			`response="8ca523f5e9506fed4657c9700eebdbec", qop=auth, nc=00000001, ` +
+			`cnonce="f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"`},
+		Authorization{
+			Method:   AuthMethodDigest,
+			Username: "Mufasa",
+			Realm:    "http-auth@example.org",
+			Nonce:    "7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v",
+			URI:      "/dir/index.html",
+			Response: "8ca523f5e9506fed4657c9700eebdbec",
+			Qop:      new("auth"),
+			Cnonce:   new("f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"),
+			Nc:       new("00000001"),
+		},
+	},
+	{
 		"digest",
 		base.HeaderValue{`Digest username="Mufasa", realm="testrealm@host.com", ` +
 			`nonce="dcd98b7102dd2f0e8b11d0f600bfb0c093", ` +


### PR DESCRIPTION
Fixes #1074.

The client never looked at the `qop` directive of a digest challenge. It always computed the legacy RFC 2069 response, so a server that requires `qop="auth"`, which most RFC 7616 implementations do, rejects every request with a 401 and the stream never starts.

This parses `qop` in WWW-Authenticate and, when the server offers `auth`, sends `qop`, `cnonce` and `nc` and computes the response as `H(HA1:nonce:nc:cnonce:qop:HA2)` (RFC 7616, section 3.4.1). The nonce count increases on every request that reuses the nonce, and the client nonce stays constant for the session. Challenges without `qop` keep the exact previous behavior, and `auth-int` is not implemented, it falls back to the legacy computation.

The response formula is pinned by the test vectors in RFC 7616 section 3.9.1, which I used as the expected values in the header round-trip test.

While in there, the `opaque` value of the challenge is now copied into the Authorization header. It was already parsed and marshalable but never set; RFC 7616 section 3.3 says the client should return it unchanged.

The server side of this package does not advertise or verify `qop`, which is why the existing round-trip tests never caught this. I left that out to keep the change focused, happy to follow up if you want it.