### PR TITLE
rtph264, rtph265: do not split an SEI NAL unit on an inner start code

### DIFF
--- a/pkg/format/rtph264/decoder.go
+++ b/pkg/format/rtph264/decoder.go
@@ -31,6 +31,12 @@ func joinFragments(fragments [][]byte, size int) []byte {
 // Even though fragments must contain only
 // one NAL unit, some vendors put multiple anyway.
 func splitNALUs(b []byte) [][]byte {
+	// do not treat start codes inside an SEI as NAL delimiters:
+	// ONVIF Media Signing makes emulation prevention optional in its SEI.
+	if len(b) > 0 && h264.NALUType(b[0]&0x1F) == h264.NALUTypeSEI {
+		return [][]byte{b}
+	}
+
 	startCode := []byte{0x00, 0x00, 0x01}
 	nalus := make([][]byte, 0, 1)
 	for len(b) > 0 {
@@ -312,7 +318,11 @@ func (d *Decoder) removeAnnexB(nalus [][]byte) ([][]byte, error) {
 	if len(nalus) == 1 {
 		nalu := nalus[0]
 
-		if !d.annexBMode && bytes.Contains(nalu, []byte{0x00, 0x00, 0x00, 0x01}) {
+		// an SEI must not enable Annex-B mode (ONVIF Media Signing makes
+		// emulation prevention optional in its SEI). Once a non-SEI NALU has
+		// enabled it, SEIs are still split like every other NALU.
+		if !d.annexBMode && len(nalu) > 0 && h264.NALUType(nalu[0]&0x1F) != h264.NALUTypeSEI &&
+			bytes.Contains(nalu, []byte{0x00, 0x00, 0x00, 0x01}) {
 			d.annexBMode = true
 		}
 

--- a/pkg/format/rtph264/decoder_test.go
+++ b/pkg/format/rtph264/decoder_test.go
@@ -358,6 +358,168 @@ var casesDecodeOnly = []struct {
 			},
 		},
 	},
+	{
+		"SEI with inner start code, fragmented (ONVIF Media Signing without emulation prevention)",
+		[]*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         false,
+					PayloadType:    96,
+					SequenceNumber: 17645,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: mergeBytes(
+					[]byte{0x1c, 0x86}, // FU-A, start, type 6
+					[]byte{0x05, 0x18},
+					[]byte{0x00, 0x5b, 0xc9, 0x3f, 0x2d, 0x71, 0x5e, 0x95, 0xad, 0xa4, 0x79, 0x6f, 0x90, 0x87, 0x7a, 0x6f},
+					[]byte{0xaa, 0xbb, 0x00, 0x00},
+				),
+			},
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 17646,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: mergeBytes(
+					[]byte{0x1c, 0x46}, // FU-A, end, type 6
+					[]byte{0x00, 0x01, 0xcc, 0xdd, 0x80},
+				),
+			},
+		},
+		[][]byte{
+			mergeBytes(
+				[]byte{0x06, 0x05, 0x18},
+				[]byte{0x00, 0x5b, 0xc9, 0x3f, 0x2d, 0x71, 0x5e, 0x95, 0xad, 0xa4, 0x79, 0x6f, 0x90, 0x87, 0x7a, 0x6f},
+				[]byte{0xaa, 0xbb, 0x00, 0x00, 0x00, 0x01, 0xcc, 0xdd, 0x80},
+			),
+		},
+	},
+	{
+		"SEI with inner 3-byte start code, fragmented",
+		[]*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         false,
+					PayloadType:    96,
+					SequenceNumber: 17645,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{0x1c, 0x86, 0x05, 0x04, 0xaa, 0x00},
+			},
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 17646,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{0x1c, 0x46, 0x00, 0x01, 0xbb, 0x80},
+			},
+		},
+		[][]byte{
+			{0x06, 0x05, 0x04, 0xaa, 0x00, 0x00, 0x01, 0xbb, 0x80},
+		},
+	},
+	{
+		"SEI with inner start code, single packet, does not enable Annex-B mode",
+		[]*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         false,
+					PayloadType:    96,
+					SequenceNumber: 17645,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{0x06, 0x05, 0x04, 0x00, 0x00, 0x00, 0x01, 0x80},
+			},
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 17646,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{0x06, 0x05, 0x04, 0x00, 0x00, 0x00, 0x01, 0x81},
+			},
+		},
+		[][]byte{
+			{0x06, 0x05, 0x04, 0x00, 0x00, 0x00, 0x01, 0x80},
+			{0x06, 0x05, 0x04, 0x00, 0x00, 0x00, 0x01, 0x81},
+		},
+	},
+	{
+		"Annex-B packet with a leading start code and an SEI still enables Annex-B mode",
+		[]*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 17647,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{
+					0x00, 0x00, 0x00, 0x01, 0x06, 0x05, 0x04, 0xaa,
+					0x00, 0x00, 0x00, 0x01, 0x65, 0xbb,
+				},
+			},
+		},
+		[][]byte{
+			{0x06, 0x05, 0x04, 0xaa},
+			{0x65, 0xbb},
+		},
+	},
+	{
+		"SEI is still split once a non-SEI NALU has enabled Annex-B mode",
+		[]*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         false,
+					PayloadType:    96,
+					SequenceNumber: 17645,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{
+					0x00, 0x00, 0x00, 0x01, 0x65, 0xaa,
+					0x00, 0x00, 0x00, 0x01, 0x65, 0xbb,
+				},
+			},
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 17646,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{0x06, 0x05, 0x04, 0x00, 0x00, 0x00, 0x01, 0x80},
+			},
+		},
+		[][]byte{
+			{0x65, 0xaa},
+			{0x65, 0xbb},
+			{0x06, 0x05, 0x04},
+			{0x80},
+		},
+	},
 }
 
 func TestDecodeOnly(t *testing.T) {

--- a/pkg/format/rtph265/decoder.go
+++ b/pkg/format/rtph265/decoder.go
@@ -31,6 +31,15 @@ func joinFragments(fragments [][]byte, size int) []byte {
 // Even though fragments must contain only
 // one NAL unit, some vendors put multiple anyway.
 func splitNALUs(b []byte) [][]byte {
+	// do not treat start codes inside an SEI as NAL delimiters:
+	// ONVIF Media Signing makes emulation prevention optional in its SEI.
+	if len(b) > 0 {
+		typ := h265.NALUType((b[0] >> 1) & 0b111111)
+		if typ == h265.NALUType_PREFIX_SEI_NUT || typ == h265.NALUType_SUFFIX_SEI_NUT {
+			return [][]byte{b}
+		}
+	}
+
 	startCode := []byte{0x00, 0x00, 0x01}
 	nalus := make([][]byte, 0, 1)
 

--- a/pkg/format/rtph265/decoder_test.go
+++ b/pkg/format/rtph265/decoder_test.go
@@ -250,6 +250,78 @@ var casesDecodeOnly = []struct {
 			},
 		},
 	},
+	{
+		"prefix SEI with inner start code, fragmented (ONVIF Media Signing without emulation prevention)",
+		[]*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         false,
+					PayloadType:    96,
+					SequenceNumber: 17645,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: mergeBytes(
+					[]byte{0x62, 0x01, 0xa7}, // FU, start, type 39
+					[]byte{0x05, 0x18},
+					[]byte{0x00, 0x5b, 0xc9, 0x3f, 0x2d, 0x71, 0x5e, 0x95, 0xad, 0xa4, 0x79, 0x6f, 0x90, 0x87, 0x7a, 0x6f},
+					[]byte{0xaa, 0xbb, 0x00, 0x00},
+				),
+			},
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 17646,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: mergeBytes(
+					[]byte{0x62, 0x01, 0x67}, // FU, end, type 39
+					[]byte{0x00, 0x01, 0xcc, 0xdd, 0x80},
+				),
+			},
+		},
+		[][]byte{
+			mergeBytes(
+				[]byte{0x4e, 0x01, 0x05, 0x18},
+				[]byte{0x00, 0x5b, 0xc9, 0x3f, 0x2d, 0x71, 0x5e, 0x95, 0xad, 0xa4, 0x79, 0x6f, 0x90, 0x87, 0x7a, 0x6f},
+				[]byte{0xaa, 0xbb, 0x00, 0x00, 0x00, 0x01, 0xcc, 0xdd, 0x80},
+			),
+		},
+	},
+	{
+		"suffix SEI with inner start code, fragmented",
+		[]*rtp.Packet{
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         false,
+					PayloadType:    96,
+					SequenceNumber: 17645,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{0x62, 0x01, 0xa8, 0x05, 0x04, 0xaa, 0x00, 0x00}, // FU, start, type 40
+			},
+			{
+				Header: rtp.Header{
+					Version:        2,
+					Marker:         true,
+					PayloadType:    96,
+					SequenceNumber: 17646,
+					Timestamp:      2289531307,
+					SSRC:           0x9dbb7812,
+				},
+				Payload: []byte{0x62, 0x01, 0x68, 0x00, 0x01, 0xbb, 0x80}, // FU, end, type 40
+			},
+		},
+		[][]byte{
+			{0x50, 0x01, 0x05, 0x04, 0xaa, 0x00, 0x00, 0x00, 0x01, 0xbb, 0x80},
+		},
+	},
 }
 
 func TestDecodeOnly(t *testing.T) {


### PR DESCRIPTION
Fixes #1156.

An SEI payload is opaque to the decoder and may legally contain start codes: ONVIF Media Signing (26.06, §5.7.1 / §5.11) makes emulation prevention optional inside its SEI, and its published test vectors carry a raw `00 00 00 01` inside a 2.7 KB certificate-bearing SEI. `splitNALUs` then cut that SEI into three NAL units (types 6, 21, 0) and the single-NAL Annex-B latch in `removeAnnexB` did the same, destroying the signed document on ingest.

With this change:

- `splitNALUs` returns an SEI (H.264 type 6; H.265 types 39 and 40) whole instead of cutting it on an inner start code.
- An SEI no longer enables Annex-B mode. Once a non-SEI NAL unit has enabled it, SEIs are still split like every other NAL unit, so a genuine Annex-B camera's output is unchanged (two new cases pin that).

The #199 and #989 fixtures are untouched: the bundles those devices send begin with a start code, an SPS/VPS, or type 0, never an SEI.

**Known residual:** a device that concatenates `SEI + start code + IDR` into one FU or single-NAL packet *without* a leading start code would now have the IDR swallowed into the SEI. That shape is not in the #199/#989 captures (they start with SPS/VPS or `00 00 00 01`, which still latch), and it is byte-indistinguishable from a signing SEI without parsing the SEI payload size, so it is left out of scope here.

Tests: seven decode-only cases added (five H.264, two H.265); the five SEI-exemption cases fail on `main` and pass with the fix, the two latch-pinning cases pass on both. `go test ./pkg/format/...`, `go vet`, and `golangci-lint run` (v2.13.2, the `make lint` image) are clean; the `FuzzDecoder` seed corpus passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
