### PR TITLE
remove Content-Length from HTTP tunnel GET request

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1193,11 +1193,9 @@ func TestClientTunnelHTTP(t *testing.T) {
 					RequestURI: "/teststream",
 					Header: http.Header{
 						"Accept":          []string{"application/x-rtsp-tunnelled"},
-						"Content-Length":  []string{"30000"},
 						"X-Sessioncookie": req1.Header["X-Sessioncookie"],
 					},
-					ContentLength: 30000,
-					Body:          req1.Body,
+					Body: req1.Body,
 				}, req1)
 
 				require.NotEmpty(t, req1.Header.Get("X-Sessioncookie"))
@@ -1381,11 +1379,9 @@ func TestClientTunnelHTTPPostResponseAfterRTSPRequest(t *testing.T) {
 					RequestURI: "/teststream",
 					Header: http.Header{
 						"Accept":          []string{"application/x-rtsp-tunnelled"},
-						"Content-Length":  []string{"30000"},
 						"X-Sessioncookie": req1.Header["X-Sessioncookie"],
 					},
-					ContentLength: 30000,
-					Body:          req1.Body,
+					Body: req1.Body,
 				}, req1)
 
 				require.NotEmpty(t, req1.Header.Get("X-Sessioncookie"))
@@ -1565,11 +1561,9 @@ func TestClientTunnelHTTPPathQuery(t *testing.T) {
 					RequestURI: "/teststream?param=value",
 					Header: http.Header{
 						"Accept":          []string{"application/x-rtsp-tunnelled"},
-						"Content-Length":  []string{"30000"},
 						"X-Sessioncookie": req1.Header["X-Sessioncookie"],
 					},
-					ContentLength: 30000,
-					Body:          req1.Body,
+					Body: req1.Body,
 				}, req1)
 
 				require.NotEmpty(t, req1.Header.Get("X-Sessioncookie"))

--- a/client_tunnel_http.go
+++ b/client_tunnel_http.go
@@ -135,7 +135,6 @@ func newClientTunnelHTTP(
 			"Host: " + addr + "\r\n" +
 			"X-Sessioncookie: " + tunnelID + "\r\n" +
 			"Accept: application/x-rtsp-tunnelled\r\n" +
-			"Content-Length: 30000\r\n" +
 			"\r\n",
 	))
 	if err != nil {


### PR DESCRIPTION
Hikvision cameras wait for the promised body and never answer the GET, so the tunnel handshake times out.

The large `Content-Length` belongs on the POST only. That is the channel the client keeps writing base64 RTSP into for the life of the session. The GET is sent once with no body and only reads the response stream, so a server that honours the length treats it as an incomplete request.
